### PR TITLE
feat(load): add FreeStyle Libre CGM glucose data loader

### DIFF
--- a/src/quantifiedme/load/freestyle_libre.py
+++ b/src/quantifiedme/load/freestyle_libre.py
@@ -1,0 +1,203 @@
+"""
+Loads Abbott FreeStyle Libre continuous glucose monitor (CGM) data.
+
+Export available via LibreView: https://www.libreview.com/
+Go to Settings -> My Uploads -> Export Data
+
+The exported CSV has a few header rows followed by glucose readings.
+Two record types are present:
+  - Historic Glucose (automatic readings every 15 minutes)
+  - Scan Glucose (manual finger-stick scans)
+
+Glucose values are in mmol/L in the EU export and mg/dL in the US export.
+This loader normalizes everything to mmol/L (divide mg/dL by 18.018).
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+from ..config import load_config
+
+# Abbott's CSV starts with metadata rows before the actual data header.
+# The exact count varies by export version; we detect the header by
+# looking for the "Device Timestamp" column.
+_HEADER_COL = "Device Timestamp"
+
+# Record type IDs in the Abbott export
+_RECORD_HISTORIC = 0  # automatic 15-min reading
+_RECORD_SCAN = 1      # manual scan
+
+
+def load_glucose_df(
+    path: Path | None = None,
+    unit: str = "mmol/L",
+) -> pd.DataFrame:
+    """
+    Load FreeStyle Libre glucose data.
+
+    Returns a DataFrame with columns:
+    - glucose: blood glucose value (mmol/L by default)
+    - record_type: 'historic' (automatic) or 'scan' (manual)
+
+    Parameters
+    ----------
+    path:
+        Path to the LibreView CSV export. Falls back to config if None.
+    unit:
+        Output unit. Either 'mmol/L' (default) or 'mg/dL'.
+    """
+    if path is None:
+        config = load_config()
+        path = Path(config["data"]["freestyle_libre"]).expanduser()
+    else:
+        path = Path(path).expanduser()
+
+    assert path.exists(), f"FreeStyle Libre export not found at {path}"
+
+    # Skip the metadata header rows — find the line with the column headers
+    with open(path, encoding="utf-8-sig") as f:
+        lines = f.readlines()
+
+    header_line = next(
+        (i for i, line in enumerate(lines) if _HEADER_COL in line),
+        None,
+    )
+    if header_line is None:
+        raise ValueError(
+            f"Could not find '{_HEADER_COL}' column in {path}. "
+            "Is this a valid FreeStyle Libre export?"
+        )
+
+    # index_col=False: Abbott exports often have a trailing comma, creating N+1
+    # fields per row. Without this, pandas auto-assigns the first column as the
+    # row index, shifting all column assignments by one.
+    df = pd.read_csv(path, skiprows=header_line, low_memory=False, index_col=False)
+
+    # Normalize column names
+    df.columns = [c.strip() for c in df.columns]
+
+    # Parse timestamps
+    df["timestamp"] = pd.to_datetime(df["Device Timestamp"], dayfirst=True, utc=True)
+    df = df.set_index("timestamp").sort_index()
+
+    # Determine if historic or scan reading and extract glucose value
+    # Historic readings: column "Historic Glucose mmol/L" or "Historic Glucose mg/dL"
+    # Scan readings: column "Scan Glucose mmol/L" or "Scan Glucose mg/dL"
+    glucose_col_mmol = _find_col(df, ["Historic Glucose mmol/L", "Scan Glucose mmol/L"])
+    glucose_col_mgdl = _find_col(df, ["Historic Glucose mg/dL", "Scan Glucose mg/dL"])
+
+    if glucose_col_mmol:
+        # EU export — values already in mmol/L
+        historic_col = next((c for c in df.columns if "Historic Glucose" in c and "mmol" in c), None)
+        scan_col = next((c for c in df.columns if "Scan Glucose" in c and "mmol" in c), None)
+        factor = 1.0
+    elif glucose_col_mgdl:
+        # US export — convert mg/dL to mmol/L
+        historic_col = next((c for c in df.columns if "Historic Glucose" in c and "mg" in c), None)
+        scan_col = next((c for c in df.columns if "Scan Glucose" in c and "mg" in c), None)
+        factor = 1 / 18.018
+    else:
+        raise ValueError(
+            "Could not find glucose columns in export. "
+            f"Available columns: {list(df.columns)}"
+        )
+
+    records = []
+    if historic_col and historic_col in df.columns:
+        hist = df[[historic_col]].dropna(subset=[historic_col]).copy()
+        hist["glucose"] = pd.to_numeric(hist[historic_col], errors="coerce") * factor
+        hist["record_type"] = "historic"
+        records.append(hist[["glucose", "record_type"]])
+
+    if scan_col and scan_col in df.columns:
+        scan = df[[scan_col]].dropna(subset=[scan_col]).copy()
+        scan["glucose"] = pd.to_numeric(scan[scan_col], errors="coerce") * factor
+        scan["record_type"] = "scan"
+        records.append(scan[["glucose", "record_type"]])
+
+    if not records:
+        raise ValueError("No glucose readings found in export.")
+
+    result = pd.concat(records).sort_index()
+    result = result.dropna(subset=["glucose"])
+
+    if unit == "mg/dL":
+        result["glucose"] = result["glucose"] * 18.018
+
+    return result
+
+
+def load_glucose_daily_df(path: Path | None = None) -> pd.DataFrame:
+    """
+    Load FreeStyle Libre data aggregated to daily stats.
+
+    Returns a DataFrame indexed by date with columns:
+    - glucose_mean: daily mean glucose (mmol/L)
+    - glucose_min: daily min
+    - glucose_max: daily max
+    - glucose_std: daily std dev (variability)
+    - time_in_range: fraction of readings in 3.9-10.0 mmol/L (standard TIR range)
+    - n_readings: number of readings that day
+    """
+    df = load_glucose_df(path=path)
+
+    daily = df.groupby(df.index.date).agg(
+        glucose_mean=("glucose", "mean"),
+        glucose_min=("glucose", "min"),
+        glucose_max=("glucose", "max"),
+        glucose_std=("glucose", "std"),
+        n_readings=("glucose", "count"),
+    )
+    # Time in range (3.9–10.0 mmol/L)
+    in_range = df[(df["glucose"] >= 3.9) & (df["glucose"] <= 10.0)]
+    tir = in_range.groupby(in_range.index.date).size() / df.groupby(df.index.date).size()
+    daily["time_in_range"] = tir
+
+    daily.index = pd.to_datetime(daily.index, utc=True)
+    daily.index.name = "timestamp"
+    return daily
+
+
+def create_fake_glucose_df(
+    start: str = "2024-01-01",
+    end: str = "2024-01-31",
+    interval_minutes: int = 15,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """
+    Generate fake CGM data for testing and notebook demos.
+
+    Simulates realistic glucose fluctuations around a stable baseline
+    with meal-time spikes and overnight stability.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    timestamps = pd.date_range(start=start, end=end, freq=f"{interval_minutes}min", tz="UTC")
+    n = len(timestamps)
+
+    # Baseline ~5.5 mmol/L with diurnal variation and random walk noise
+    hours = timestamps.hour.to_numpy() + timestamps.minute.to_numpy() / 60
+    # Meal spikes at 8h, 13h, 19h
+    meal_effect = (
+        2.0 * np.exp(-0.5 * ((hours - 8) % 24) ** 2)
+        + 2.5 * np.exp(-0.5 * ((hours - 13) % 24) ** 2)
+        + 2.0 * np.exp(-0.5 * ((hours - 19) % 24) ** 2)
+    )
+    noise = rng.normal(0, 0.3, n)
+    glucose = (5.5 + meal_effect * 0.4 + noise).clip(3.0, 15.0)
+
+    df = pd.DataFrame(
+        {"glucose": glucose, "record_type": "historic"},
+        index=timestamps,
+    )
+    df.index.name = "timestamp"
+    return df
+
+
+def _find_col(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    for c in candidates:
+        if c in df.columns:
+            return c
+    return None

--- a/src/quantifiedme/load/freestyle_libre.py
+++ b/src/quantifiedme/load/freestyle_libre.py
@@ -80,7 +80,7 @@ def load_glucose_df(
     df = pd.read_csv(path, skiprows=header_line, low_memory=False, index_col=False)
 
     # Normalize column names
-    df.columns = [c.strip() for c in df.columns]
+    df.columns = pd.Index([c.strip() for c in df.columns])
 
     # Parse timestamps
     df["timestamp"] = pd.to_datetime(df["Device Timestamp"], dayfirst=True, utc=True)
@@ -146,8 +146,9 @@ def load_glucose_daily_df(path: Path | None = None) -> pd.DataFrame:
     - n_readings: number of readings that day
     """
     df = load_glucose_df(path=path)
+    idx = pd.DatetimeIndex(df.index)
 
-    daily = df.groupby(df.index.date).agg(
+    daily = df.groupby(idx.date).agg(
         glucose_mean=("glucose", "mean"),
         glucose_min=("glucose", "min"),
         glucose_max=("glucose", "max"),
@@ -156,7 +157,8 @@ def load_glucose_daily_df(path: Path | None = None) -> pd.DataFrame:
     )
     # Time in range (3.9–10.0 mmol/L)
     in_range = df[(df["glucose"] >= 3.9) & (df["glucose"] <= 10.0)]
-    tir = in_range.groupby(in_range.index.date).size() / df.groupby(df.index.date).size()
+    in_range_idx = pd.DatetimeIndex(in_range.index)
+    tir = in_range.groupby(in_range_idx.date).size() / df.groupby(idx.date).size()
     daily["time_in_range"] = tir
 
     daily.index = pd.to_datetime(daily.index, utc=True)

--- a/src/quantifiedme/load/freestyle_libre.py
+++ b/src/quantifiedme/load/freestyle_libre.py
@@ -53,7 +53,12 @@ def load_glucose_df(
     else:
         path = Path(path).expanduser()
 
-    assert path.exists(), f"FreeStyle Libre export not found at {path}"
+    if not path.exists():
+        raise FileNotFoundError(f"FreeStyle Libre export not found at {path}")
+
+    valid_units = {"mmol/L", "mg/dL"}
+    if unit not in valid_units:
+        raise ValueError(f"Invalid unit {unit!r}. Must be one of: {valid_units}")
 
     # Skip the metadata header rows — find the line with the column headers
     with open(path, encoding="utf-8-sig") as f:

--- a/tests/test_load_freestyle_libre.py
+++ b/tests/test_load_freestyle_libre.py
@@ -43,7 +43,7 @@ def test_load_glucose_df_mmol(sample_csv_mmol: Path) -> None:
     assert "record_type" in df.columns
     assert df.index.name == "timestamp"
     assert isinstance(df.index, pd.DatetimeIndex)
-    assert df.index.tz is not None  # timezone-aware
+    assert str(df.index.tz) == "UTC"  # must be explicitly UTC, not just tz-aware
     # 5 historic + 1 scan = 6 readings
     assert len(df) == 6
 
@@ -86,7 +86,7 @@ def test_create_fake_glucose_df() -> None:
     assert isinstance(df, pd.DataFrame)
     assert "glucose" in df.columns
     assert isinstance(df.index, pd.DatetimeIndex)
-    assert df.index.tz is not None
+    assert str(df.index.tz) == "UTC"
     # Jan 1 00:00 to Jan 7 00:00 inclusive = 6*24*4 + 1 = 577 readings at 15min intervals
     assert len(df) == 577
     # Values should be physiologically plausible
@@ -107,3 +107,14 @@ def test_load_glucose_mgdl_unit(sample_csv_mmol: Path) -> None:
     # mg/dL values should be ~18x higher than mmol/L
     ratio = (df_mgdl["glucose"] / df_mmol["glucose"]).mean()
     assert abs(ratio - 18.018) < 0.1
+
+
+def test_load_glucose_df_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.csv"
+    with pytest.raises(FileNotFoundError, match="nonexistent.csv"):
+        load_glucose_df(path=missing)
+
+
+def test_load_glucose_df_invalid_unit(sample_csv_mmol: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid unit"):
+        load_glucose_df(path=sample_csv_mmol, unit="kg/m2")

--- a/tests/test_load_freestyle_libre.py
+++ b/tests/test_load_freestyle_libre.py
@@ -42,6 +42,7 @@ def test_load_glucose_df_mmol(sample_csv_mmol: Path) -> None:
     assert "glucose" in df.columns
     assert "record_type" in df.columns
     assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert df.index.tz is not None  # timezone-aware
     # 5 historic + 1 scan = 6 readings
     assert len(df) == 6
@@ -84,6 +85,7 @@ def test_create_fake_glucose_df() -> None:
 
     assert isinstance(df, pd.DataFrame)
     assert "glucose" in df.columns
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert df.index.tz is not None
     # Jan 1 00:00 to Jan 7 00:00 inclusive = 6*24*4 + 1 = 577 readings at 15min intervals
     assert len(df) == 577

--- a/tests/test_load_freestyle_libre.py
+++ b/tests/test_load_freestyle_libre.py
@@ -1,0 +1,107 @@
+"""Tests for the FreeStyle Libre CGM data loader."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from quantifiedme.load.freestyle_libre import (
+    create_fake_glucose_df,
+    load_glucose_daily_df,
+    load_glucose_df,
+)
+
+
+# Minimal valid LibreView CSV export (EU mmol/L format)
+# Abbott exports include 2 header rows before the column header
+SAMPLE_CSV_MMOL = """\
+FreeStyle LibreLink - John Doe - 2024-01-31 12:00 UTC.csv
+Device Name,Device Serial Number,
+LibreLink,ABC-12345-67890,
+Device Timestamp,Record Type,Historic Glucose mmol/L,Scan Glucose mmol/L,Non-numeric Rapid-Acting Insulin,Rapid-Acting Insulin (units),Non-numeric Food,Carbohydrates (grams),Carbohydrates (servings),Non-numeric Long-Acting Insulin,Long-Acting Insulin (units),Notes,Strip Glucose mmol/L,Ketone mmol/L,Meal Insulin (units),Correction Insulin (units),User Change Insulin (units)
+01-01-2024 00:00,0,5.2,,,,,,,,,,,,,,,
+01-01-2024 00:15,0,5.1,,,,,,,,,,,,,,,
+01-01-2024 01:00,1,,5.5,,,,,,,,,,,,,,
+01-01-2024 08:30,0,7.8,,,,,,,,,,,,,,,
+01-01-2024 08:45,0,8.1,,,,,,,,,,,,,,,
+01-01-2024 09:00,0,7.5,,,,,,,,,,,,,,,
+"""
+
+
+@pytest.fixture
+def sample_csv_mmol(tmp_path: Path) -> Path:
+    p = tmp_path / "glucosedata.csv"
+    p.write_text(SAMPLE_CSV_MMOL)
+    return p
+
+
+def test_load_glucose_df_mmol(sample_csv_mmol: Path) -> None:
+    df = load_glucose_df(path=sample_csv_mmol)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "glucose" in df.columns
+    assert "record_type" in df.columns
+    assert df.index.name == "timestamp"
+    assert df.index.tz is not None  # timezone-aware
+    # 5 historic + 1 scan = 6 readings
+    assert len(df) == 6
+
+
+def test_load_glucose_df_sorted(sample_csv_mmol: Path) -> None:
+    df = load_glucose_df(path=sample_csv_mmol)
+    assert df.index.is_monotonic_increasing
+
+
+def test_load_glucose_df_record_types(sample_csv_mmol: Path) -> None:
+    df = load_glucose_df(path=sample_csv_mmol)
+    assert set(df["record_type"].unique()).issubset({"historic", "scan"})
+    assert (df["record_type"] == "historic").sum() == 5
+    assert (df["record_type"] == "scan").sum() == 1
+
+
+def test_load_glucose_df_values_range(sample_csv_mmol: Path) -> None:
+    df = load_glucose_df(path=sample_csv_mmol)
+    # All values should be in physiologically plausible mmol/L range
+    assert (df["glucose"] > 2.0).all()
+    assert (df["glucose"] < 25.0).all()
+
+
+def test_load_glucose_daily_df(sample_csv_mmol: Path) -> None:
+    df = load_glucose_daily_df(path=sample_csv_mmol)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "glucose_mean" in df.columns
+    assert "glucose_min" in df.columns
+    assert "glucose_max" in df.columns
+    assert "time_in_range" in df.columns
+    assert "n_readings" in df.columns
+    # Only one day of data in sample
+    assert len(df) == 1
+
+
+def test_create_fake_glucose_df() -> None:
+    df = create_fake_glucose_df(start="2024-01-01", end="2024-01-07")
+
+    assert isinstance(df, pd.DataFrame)
+    assert "glucose" in df.columns
+    assert df.index.tz is not None
+    # Jan 1 00:00 to Jan 7 00:00 inclusive = 6*24*4 + 1 = 577 readings at 15min intervals
+    assert len(df) == 577
+    # Values should be physiologically plausible
+    assert (df["glucose"] > 2.5).all()
+    assert (df["glucose"] < 16.0).all()
+
+
+def test_fake_glucose_df_reproducible() -> None:
+    df1 = create_fake_glucose_df(seed=0)
+    df2 = create_fake_glucose_df(seed=0)
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_load_glucose_mgdl_unit(sample_csv_mmol: Path) -> None:
+    df_mmol = load_glucose_df(path=sample_csv_mmol, unit="mmol/L")
+    df_mgdl = load_glucose_df(path=sample_csv_mmol, unit="mg/dL")
+
+    # mg/dL values should be ~18x higher than mmol/L
+    ratio = (df_mgdl["glucose"] / df_mmol["glucose"]).mean()
+    assert abs(ratio - 18.018) < 0.1


### PR DESCRIPTION
## Summary

Adds a loader for Abbott FreeStyle Libre continuous glucose monitor (CGM) data — one of the high-value sources identified in the QS data inventory (#11). Glucose data correlates with energy, cognition, and food, making it one of the most actionable biomarkers to track.

**Files added:**
- [`src/quantifiedme/load/freestyle_libre.py`](https://github.com/TimeToLearnAlice/quantifiedme/blob/feat/freestyle-libre-loader/src/quantifiedme/load/freestyle_libre.py) — CGM loader
- [`tests/test_load_freestyle_libre.py`](https://github.com/TimeToLearnAlice/quantifiedme/blob/feat/freestyle-libre-loader/tests/test_load_freestyle_libre.py) — 8-test suite

## What it does

- `load_glucose_df(path, unit)` — loads raw CGM readings; returns timezone-aware timestamps with `glucose` (mmol/L by default) and `record_type` ('historic' = auto 15-min, 'scan' = manual)
- `load_glucose_daily_df(path)` — daily aggregates: mean, min, max, std, **time-in-range** (fraction of readings in 3.9–10.0 mmol/L standard TIR window), and reading count
- `create_fake_glucose_df(start, end, seed)` — realistic fake CGM trace with diurnal variation and meal spikes at 8h/13h/19h for notebooks

## Format support

- **EU format**: mmol/L columns (most users)
- **US format**: mg/dL columns — auto-detected and converted to mmol/L
- Handles Abbott's metadata header rows (auto-detected by looking for "Device Timestamp" column)
- Works around Abbott's **trailing-comma quirk** — the export adds an extra trailing comma per row, which causes pandas to shift all columns by 1 without `index_col=False`

## Config

Add to `~/.config/quantifiedme/config.toml`:
```toml
[data]
freestyle_libre = "~/Downloads/glucosedata.csv"
```

## Tests (8 passing)

- CSV parsing with column normalization
- Sort order
- Record type detection (historic vs scan)
- Physiological range check
- Daily aggregation (TIR, mean/min/max)
- Fake data generation
- Reproducibility (seed)
- Unit conversion ratio check (mg/dL vs mmol/L ≈ 18x)

## Related

- Issue #11 (data inventory) — Freestyle Libre identified as high-priority untapped source
- See also PR #12 for Cronometer nutrition loader (companion PR)

## Summary by Sourcery

Add support for loading and aggregating Abbott FreeStyle Libre continuous glucose monitor data.

New Features:
- Introduce a glucose loader that parses FreeStyle Libre CSV exports into a normalized, timezone-aware dataframe with glucose values and reading type metadata.
- Provide a daily aggregation loader that computes summary glucose statistics and time-in-range metrics from raw readings.
- Add a utility to generate realistic fake CGM traces for testing and exploratory analysis.

Tests:
- Add a focused test suite validating CSV parsing, sorting, record-type detection, physiological bounds, daily aggregation correctness, fake data generation, reproducibility, and unit conversion behavior.