### PR TITLE
feat(load): add SwitchBot environmental sensor loader

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,14 @@ categories = "./categories.example.toml"
 #habitbull = "~/Downloads/HabitBullData.csv"
 #location = "~/location"
 #oura = "~/Downloads/oura_2020-02-27T09-07-47.json"
+#cronometer = "~/Downloads/dailysummary.csv"        # Cronometer daily nutrition export
+#cronometer_servings = "~/Downloads/servings.csv"   # Optional: Cronometer per-food-item log
+#freestyle_libre = "~/Downloads/glucosedata.csv"    # Abbott FreeStyle Libre CGM export (via LibreView)
+#switchbot = "~/Downloads/switchbot_bedroom.csv"    # SwitchBot Meter/CO2 sensor export (single device)
+
+#[data.switchbot_devices]                           # SwitchBot: multiple devices by name
+#bedroom = "~/Downloads/switchbot_bedroom.csv"
+#office = "~/Downloads/switchbot_office.csv"
 
 [data.activitywatch]
 port = 5666

--- a/src/quantifiedme/load/switchbot.py
+++ b/src/quantifiedme/load/switchbot.py
@@ -1,0 +1,201 @@
+"""
+Loads SwitchBot environmental sensor data.
+
+SwitchBot Meter, MeterPlus, and CO2 Sensor devices log temperature,
+humidity, and CO2. Data can be exported via the SwitchBot app:
+  App -> Device -> History -> Export
+
+The export produces a CSV file per device.
+
+Typical columns:
+  - Meter/MeterPlus: Time, Temperature(°C), Humidity(%)
+  - CO2 Sensor:      Time, Temperature(°C), Humidity(%), CO2(ppm)
+
+Multiple device exports (e.g., bedroom + office) can be loaded and
+merged into a single DataFrame with a device label column.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+from ..config import load_config
+
+
+def load_environment_df(
+    path: Path | str | None = None,
+    device_name: str | None = None,
+) -> pd.DataFrame:
+    """
+    Load SwitchBot environmental sensor export (single device).
+
+    Returns a DataFrame indexed by timestamp with columns:
+    - temperature_c: temperature in °C
+    - humidity_pct: relative humidity (0–100)
+    - co2_ppm: CO2 concentration in ppm (only if device supports it)
+
+    Parameters
+    ----------
+    path:
+        Path to the SwitchBot CSV export. Falls back to config if None.
+        Config key: ``data.switchbot`` (single device) or
+        ``data.switchbot_devices`` (dict of name -> path).
+    device_name:
+        Optional label to add as a column (useful when combining devices).
+    """
+    if path is None:
+        config = load_config()
+        cfg = config.get("data", {}).get("switchbot")
+        if cfg is None:
+            raise KeyError(
+                "No switchbot data path in config. "
+                "Add 'switchbot = \"~/path/to/export.csv\"' under [data]."
+            )
+        path = Path(cfg).expanduser()
+    else:
+        path = Path(path).expanduser()
+
+    assert path.exists(), f"SwitchBot export not found at {path}"
+
+    df = pd.read_csv(path)
+    df.columns = [c.strip() for c in df.columns]
+
+    # Detect timestamp column (SwitchBot uses "Time" or "Date/Time")
+    time_col = _find_col(df, ["Time", "Date/Time", "Timestamp", "Date"])
+    if time_col is None:
+        raise ValueError(
+            f"Could not find timestamp column in {path}. "
+            f"Available columns: {list(df.columns)}"
+        )
+
+    df["timestamp"] = pd.to_datetime(df[time_col], utc=True)
+    df = df.drop(columns=[time_col])
+    df = df.set_index("timestamp").sort_index()
+
+    # Normalize column names
+    col_map: dict[str, str] = {}
+    for col in df.columns:
+        lc = col.lower().strip()
+        if "temperature" in lc or "temp" in lc:
+            col_map[col] = "temperature_c"
+        elif "humidity" in lc or "humid" in lc:
+            col_map[col] = "humidity_pct"
+        elif "co2" in lc or "carbon" in lc:
+            col_map[col] = "co2_ppm"
+        else:
+            # Keep unrecognized columns but normalize name
+            col_map[col] = lc.replace(" ", "_").replace("(", "").replace(")", "").replace("%", "pct").replace("/", "_")
+
+    df = df.rename(columns=col_map)
+
+    # Keep only numeric columns
+    df = df.select_dtypes(include="number")
+
+    if device_name is not None:
+        df["device"] = device_name
+
+    return df
+
+
+def load_environment_devices_df(devices: dict[str, Path | str] | None = None) -> pd.DataFrame:
+    """
+    Load and combine multiple SwitchBot device exports.
+
+    Parameters
+    ----------
+    devices:
+        Dict mapping device name to CSV path. Falls back to
+        ``data.switchbot_devices`` in config if None.
+
+    Returns a single DataFrame with a ``device`` column to distinguish sources.
+    """
+    if devices is None:
+        config = load_config()
+        raw = config.get("data", {}).get("switchbot_devices", {})
+        devices = {name: Path(p).expanduser() for name, p in raw.items()}
+
+    if not devices:
+        raise ValueError(
+            "No devices provided. Pass a dict or configure "
+            "'switchbot_devices' under [data] in config."
+        )
+
+    dfs = []
+    for name, path in devices.items():
+        df = load_environment_df(path=path, device_name=name)
+        dfs.append(df)
+
+    return pd.concat(dfs).sort_index()
+
+
+def load_environment_daily_df(
+    path: Path | str | None = None,
+    device_name: str | None = None,
+) -> pd.DataFrame:
+    """
+    Load SwitchBot data aggregated to daily statistics.
+
+    Returns a DataFrame indexed by date with mean/min/max for each
+    sensor channel (temperature, humidity, and CO2 if available).
+    """
+    df = load_environment_df(path=path, device_name=device_name)
+
+    # Drop device column before aggregating if present
+    numeric_df = df.select_dtypes(include="number")
+
+    daily = numeric_df.groupby(numeric_df.index.date).agg(["mean", "min", "max"])
+    daily.columns = ["_".join(c) for c in daily.columns]
+    daily.index = pd.to_datetime(daily.index, utc=True)
+    daily.index.name = "timestamp"
+    return daily
+
+
+def create_fake_environment_df(
+    start: str = "2024-01-01",
+    end: str = "2024-01-31",
+    interval_minutes: int = 5,
+    include_co2: bool = True,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """
+    Generate fake SwitchBot environmental data for testing and notebooks.
+
+    Simulates realistic diurnal patterns:
+    - Temperature: warmer in the afternoon (~21°C baseline)
+    - Humidity: slightly higher at night
+    - CO2 (if include_co2): higher during occupied hours, spikes around meals
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    timestamps = pd.date_range(start=start, end=end, freq=f"{interval_minutes}min", tz="UTC")
+    n = len(timestamps)
+    hours = timestamps.hour.to_numpy() + timestamps.minute.to_numpy() / 60
+
+    # Temperature: baseline 20°C, +2°C afternoon peak, small noise
+    temp = 20.0 + 2.0 * np.sin((hours - 6) * np.pi / 12) + rng.normal(0, 0.3, n)
+    temp = temp.clip(15.0, 28.0)
+
+    # Humidity: baseline 50%, slightly higher overnight
+    humid = 50.0 - 5.0 * np.sin((hours - 6) * np.pi / 12) + rng.normal(0, 2.0, n)
+    humid = humid.clip(20.0, 85.0)
+
+    data: dict[str, object] = {"temperature_c": temp, "humidity_pct": humid}
+
+    if include_co2:
+        # CO2: outdoor ~420 ppm baseline; elevated during occupied daytime hours
+        occupied = ((hours >= 8) & (hours <= 22)).astype(float)
+        co2 = 420.0 + 200.0 * occupied + rng.normal(0, 30.0, n)
+        co2 = co2.clip(350.0, 2000.0)
+        data["co2_ppm"] = co2
+
+    df = pd.DataFrame(data, index=timestamps)
+    df.index.name = "timestamp"
+    return df
+
+
+def _find_col(df: pd.DataFrame, candidates: list[str]) -> str | None:
+    for c in candidates:
+        if c in df.columns:
+            return c
+    return None

--- a/src/quantifiedme/load/switchbot.py
+++ b/src/quantifiedme/load/switchbot.py
@@ -55,7 +55,8 @@ def load_environment_df(
     else:
         path = Path(path).expanduser()
 
-    assert path.exists(), f"SwitchBot export not found at {path}"
+    if not path.exists():
+        raise FileNotFoundError(f"SwitchBot export not found at {path}")
 
     df = pd.read_csv(path)
     df.columns = [c.strip() for c in df.columns]

--- a/tests/test_load_switchbot.py
+++ b/tests/test_load_switchbot.py
@@ -58,6 +58,7 @@ def test_load_meter_df(meter_csv: Path) -> None:
     assert "humidity_pct" in df.columns
     assert "co2_ppm" not in df.columns  # meter doesn't have CO2
     assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert df.index.tz is not None
     assert len(df) == 6
 
@@ -117,6 +118,7 @@ def test_create_fake_environment_df_with_co2() -> None:
     assert "temperature_c" in df.columns
     assert "humidity_pct" in df.columns
     assert "co2_ppm" in df.columns
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert df.index.tz is not None
 
     # Plausible ranges

--- a/tests/test_load_switchbot.py
+++ b/tests/test_load_switchbot.py
@@ -1,0 +1,139 @@
+"""Tests for the SwitchBot environmental sensor data loader."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from quantifiedme.load.switchbot import (
+    create_fake_environment_df,
+    load_environment_daily_df,
+    load_environment_df,
+    load_environment_devices_df,
+)
+
+
+# SwitchBot Meter export (temperature + humidity)
+SAMPLE_CSV_METER = """\
+Time,Temperature(°C),Humidity(%)
+2024-01-15 00:00,20.5,52
+2024-01-15 00:05,20.4,53
+2024-01-15 06:00,19.8,55
+2024-01-15 12:00,22.3,48
+2024-01-15 18:00,21.7,50
+2024-01-15 23:55,20.1,54
+"""
+
+# SwitchBot CO2 Sensor export (temperature + humidity + CO2)
+SAMPLE_CSV_CO2 = """\
+Time,Temperature(°C),Humidity(%),CO2(ppm)
+2024-01-15 00:00,20.5,52,430
+2024-01-15 00:05,20.4,53,425
+2024-01-15 09:00,21.0,49,650
+2024-01-15 12:00,22.3,48,800
+2024-01-15 18:00,21.7,50,720
+2024-01-15 23:55,20.1,54,445
+"""
+
+
+@pytest.fixture
+def meter_csv(tmp_path: Path) -> Path:
+    p = tmp_path / "bedroom_meter.csv"
+    p.write_text(SAMPLE_CSV_METER)
+    return p
+
+
+@pytest.fixture
+def co2_csv(tmp_path: Path) -> Path:
+    p = tmp_path / "office_co2.csv"
+    p.write_text(SAMPLE_CSV_CO2)
+    return p
+
+
+def test_load_meter_df(meter_csv: Path) -> None:
+    df = load_environment_df(path=meter_csv)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "temperature_c" in df.columns
+    assert "humidity_pct" in df.columns
+    assert "co2_ppm" not in df.columns  # meter doesn't have CO2
+    assert df.index.name == "timestamp"
+    assert df.index.tz is not None
+    assert len(df) == 6
+
+
+def test_load_co2_df(co2_csv: Path) -> None:
+    df = load_environment_df(path=co2_csv)
+
+    assert "co2_ppm" in df.columns
+    assert (df["co2_ppm"] > 400).all()
+    assert len(df) == 6
+
+
+def test_load_df_sorted(meter_csv: Path) -> None:
+    df = load_environment_df(path=meter_csv)
+    assert df.index.is_monotonic_increasing
+
+
+def test_load_df_with_device_name(meter_csv: Path) -> None:
+    df = load_environment_df(path=meter_csv, device_name="bedroom")
+    assert "device" in df.columns
+    assert (df["device"] == "bedroom").all()
+
+
+def test_load_devices_df(meter_csv: Path, co2_csv: Path) -> None:
+    df = load_environment_devices_df(
+        devices={"bedroom": meter_csv, "office": co2_csv}
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert "device" in df.columns
+    assert set(df["device"].unique()) == {"bedroom", "office"}
+    # Combined: 6 bedroom + 6 office = 12 rows
+    assert len(df) == 12
+
+
+def test_load_environment_daily_df(meter_csv: Path) -> None:
+    df = load_environment_daily_df(path=meter_csv)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "temperature_c_mean" in df.columns
+    assert "temperature_c_min" in df.columns
+    assert "temperature_c_max" in df.columns
+    assert "humidity_pct_mean" in df.columns
+    # Single day of data
+    assert len(df) == 1
+    # Max temp should be >= mean >= min
+    assert (df["temperature_c_max"] >= df["temperature_c_mean"]).all()
+    assert (df["temperature_c_mean"] >= df["temperature_c_min"]).all()
+
+
+def test_create_fake_environment_df_with_co2() -> None:
+    df = create_fake_environment_df(
+        start="2024-01-01", end="2024-01-07", include_co2=True
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert "temperature_c" in df.columns
+    assert "humidity_pct" in df.columns
+    assert "co2_ppm" in df.columns
+    assert df.index.tz is not None
+
+    # Plausible ranges
+    assert (df["temperature_c"] > 10).all()
+    assert (df["temperature_c"] < 35).all()
+    assert (df["humidity_pct"] > 10).all()
+    assert (df["humidity_pct"] < 100).all()
+    assert (df["co2_ppm"] > 300).all()
+    assert (df["co2_ppm"] < 2500).all()
+
+
+def test_create_fake_environment_df_no_co2() -> None:
+    df = create_fake_environment_df(include_co2=False)
+    assert "co2_ppm" not in df.columns
+
+
+def test_fake_environment_df_reproducible() -> None:
+    df1 = create_fake_environment_df(seed=0)
+    df2 = create_fake_environment_df(seed=0)
+    pd.testing.assert_frame_equal(df1, df2)


### PR DESCRIPTION
## Summary

Adds a loader for SwitchBot environmental sensor CSV exports (Meter, MeterPlus, CO2 Sensor) — the third of three high-value untapped data sources from the QS data inventory (#11). Environmental data (temperature, humidity, CO2) correlates with sleep quality and cognitive performance.

**Files added:**
- [`src/quantifiedme/load/switchbot.py`](https://github.com/TimeToLearnAlice/quantifiedme/blob/feat/switchbot-loader/src/quantifiedme/load/switchbot.py) — environmental sensor loader
- [`tests/test_load_switchbot.py`](https://github.com/TimeToLearnAlice/quantifiedme/blob/feat/switchbot-loader/tests/test_load_switchbot.py) — 9-test suite

**Also updated:**
- [`config.example.toml`](https://github.com/TimeToLearnAlice/quantifiedme/blob/feat/switchbot-loader/config.example.toml) — adds commented entries for all three new data sources (Cronometer, FreeStyle Libre, SwitchBot)

## What it does

- `load_environment_df(path, device_name)` — single device; auto-detects timestamp column, normalizes to `temperature_c`, `humidity_pct`, `co2_ppm`
- `load_environment_devices_df(devices)` — combine multiple SwitchBot devices into one DataFrame with a `device` label column (e.g., `{"bedroom": path1, "office": path2}`)
- `load_environment_daily_df(path)` — daily mean/min/max per channel
- `create_fake_environment_df(start, end, include_co2, seed)` — realistic synthetic data with diurnal patterns (temp peaks afternoon, CO2 elevated during occupied hours)

## Config

```toml
[data]
# Single device
switchbot = "~/Downloads/switchbot_bedroom.csv"

# Multiple devices
[data.switchbot_devices]
bedroom = "~/Downloads/switchbot_bedroom.csv"
office  = "~/Downloads/switchbot_office.csv"
```

## Tests (9 passing)

- Meter CSV parsing (temp + humidity only)
- CO2 sensor CSV parsing (temp + humidity + CO2)
- Sort order
- Device name label
- Multi-device combine
- Daily aggregation with min/mean/max relationship check
- Fake data with and without CO2
- Reproducibility (seed)

## Related

- Issue #11 — SwitchBot identified as high-value untapped source
- PR #12 — Cronometer nutrition loader
- PR #13 — FreeStyle Libre glucose loader

This completes all three integrations identified in the QS data inventory.

## Summary by Sourcery

Add support for loading and aggregating SwitchBot environmental sensor exports, including utilities for multi-device combination and synthetic data generation.

New Features:
- Introduce loader for SwitchBot environmental CSV exports that normalizes temperature, humidity, and optional CO2 readings into a timestamp-indexed DataFrame.
- Add helper to load and merge multiple SwitchBot device files into a single DataFrame labeled by device.
- Provide a daily aggregation loader that computes per-day mean, min, and max statistics for environmental metrics.
- Add a synthetic environmental data generator for testing and exploratory analysis with configurable time range and CO2 inclusion.

Enhancements:
- Extend example configuration to document paths and options for Cronometer, FreeStyle Libre, and SwitchBot data sources.

Tests:
- Add a SwitchBot loader test suite covering different device types, multi-device combination, daily aggregation, synthetic data generation, and reproducibility.