### PR TITLE
fix(ui): resolve mypy type errors in view_drugs

### DIFF
--- a/src/quantifiedme/ui/main.py
+++ b/src/quantifiedme/ui/main.py
@@ -313,10 +313,10 @@ def view_drugs():
         df = df[df["substance"] == substance]
 
         # sum the doses by date (multiple doses per day)
-        df = df.groupby(["date"])["dose"].sum()
-        df.index = pd.to_datetime(df.index)
+        doses = df.groupby(["date"])["dose"].sum()
+        doses.index = pd.to_datetime(doses.index)
 
-        fig, _ = calplot.calplot(df)
+        fig, _ = calplot.calplot(doses)
         return gr.Plot(fig)
 
     def dropdown_substances(df: pd.DataFrame) -> gr.Dropdown:
@@ -359,19 +359,23 @@ def view_drugs():
         with gr.Blocks():
             # top substances
             top_substances = (
-                df.groupby("substance")["dose"].count().sort_values(ascending=False)
-            )
-            top_substances = top_substances.reset_index().rename(
-                columns={"substance": "Substance", "dose": "Count"}
+                df.groupby("substance")["dose"]
+                .count()
+                .sort_values(ascending=False)
+                .reset_index()
+                .rename(columns={"substance": "Substance", "dose": "Count"})
             )
             gr.Dataframe(top_substances, label="Top substances")
 
         with gr.Blocks():
             # top tags
             # FIXME: only supports one tag per dose, but multiple tags can match
-            top_tags = df.groupby("tag")["dose"].count().sort_values(ascending=False)
-            top_tags = top_tags.reset_index().rename(
-                columns={"tag": "Tag", "dose": "Count"}
+            top_tags = (
+                df.groupby("tag")["dose"]
+                .count()
+                .sort_values(ascending=False)
+                .reset_index()
+                .rename(columns={"tag": "Tag", "dose": "Count"})
             )
             gr.Dataframe(top_tags, label="Top tags")
 


### PR DESCRIPTION
## Summary

Fixes 3 mypy errors in `src/quantifiedme/ui/main.py` that have been causing CI typecheck failures across all open PRs (#12, #13, #16).

**Errors fixed** (all in `view_drugs()`):
- Line 316: `df = df.groupby(...)["dose"].sum()` — reassigning `DataFrame` param to `Series` → renamed to `doses`
- Line 364: `top_substances = top_substances.reset_index()` — `Series` reassigned to `DataFrame` → chained into single expression
- Line 373: `top_tags = top_tags.reset_index()` — same pattern → chained into single expression

**No behavior change** — purely a type annotation fix. The logic is identical; variables are renamed or operations chained to satisfy mypy.

## Why this matters

All three data loader PRs (#12 Cronometer, #13 FreeStyle Libre, #16 Home Assistant) were showing CI failures entirely due to these pre-existing errors in `main.py`, not anything introduced by the loaders. Fixing this will make the typecheck job pass on those PRs.

## Summary by Sourcery

Resolve mypy type errors in the view_drugs UI logic to restore passing type checks without changing runtime behavior.

Bug Fixes:
- Rename intermediate dose aggregation result to avoid reassigning a DataFrame parameter to a Series.
- Chain groupby, count, sort, reset_index, and rename operations for top substances and tags to keep types consistent and mypy-compliant.