### PR TITLE
fix(ci): add checkout step to deploy job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notebooks]
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: notebooks


### PR DESCRIPTION
## Summary

- The deploy job was missing an `actions/checkout@v4` step, causing `github-pages-deploy-action@v4` to fail with `fatal: not in a git directory`
- The action needs a git repo context to configure git and push to the `gh-pages` branch
- This fixes the deploy failure Erik flagged on #18

## Context

After upgrading `github-pages-deploy-action` from v3 to v4 in #18, the deploy job started failing because v4 requires a git repository context (v3 may have handled this differently). Adding a checkout step before the artifact download provides the necessary `.git` directory.

## Test plan

- [ ] CI deploy job passes on this PR
- [ ] After merge, master branch deploy succeeds

## Summary by Sourcery

CI:
- Update the deploy workflow to run actions/checkout before downloading artifacts and running the GitHub Pages deploy action.