### PR TITLE
feat: enable comprehensive ruff lint rules matching gptme config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,35 @@ markers = [
 strictParameterNoneValue = false
 pythonVersion = "3.10"
 
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E4", "E7", "E9",  # pycodestyle
+    "F",      # pyflakes
+    "B",      # flake8-bugbear
+    "UP",     # pyupgrade
+    "I",      # isort
+    "C4",     # flake8-comprehensions
+    "FURB",   # refurb
+    "FLY",    # flynt (f-string over join)
+    "ISC",    # implicit-str-concat
+    "PLE",    # pylint errors
+    "PERF",   # perflint
+    "RSE102", # unnecessary-paren-on-raise-exception
+    "SIM103", "SIM110", "SIM117", "SIM118", "SIM300", "SIM910",  # flake8-simplify
+    "PIE790", "PIE810",  # flake8-pie
+    "RET501", "RET505", "RET506", "RET507", "RET508",  # flake8-return
+    "RUF010", "RUF019", "RUF100",  # ruff-specific
+    "TC001", "TC002", "TC003", "TC004",  # flake8-type-checking
+    "DTZ",    # flake8-datetimez (require timezone-aware datetimes)
+]
+ignore = ["E402", "E501", "PERF203", "DTZ"]  # DTZ: tz-aware datetimes deferred (data pipeline uses naive)
+
+[tool.ruff.lint.isort]
+known-first-party = ["quantifiedme"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/quantifiedme/derived/all_df.py
+++ b/src/quantifiedme/derived/all_df.py
@@ -27,12 +27,14 @@ Sources = Literal["screentime", "heartrate", "drugs", "location", "sleep"]
 def load_all_df(
     fast=True,
     screentime_events: list[Event] | None = None,
-    ignore: list[Sources] = [],
+    ignore: list[Sources] | None = None,
 ) -> pd.DataFrame:
     """
     Loads a bunch of data into a single dataframe with one row per day.
     Serves as a useful starting point for further analysis.
     """
+    if ignore is None:
+        ignore = []
     df = pd.DataFrame()
     since = datetime.now(tz=timezone.utc) - timedelta(days=30 if fast else 2 * 365)
     print(f"Loading data since {since}")
@@ -82,7 +84,7 @@ def load_all_df(
     # look for all-na columns, emit a warning, and drop them
     na_cols = df.columns[df.isna().all()]
     if len(na_cols) > 0:
-        logger.warning(f"Warning: dropping all-NA columns: {str(list(na_cols))}")
+        logger.warning(f"Warning: dropping all-NA columns: {list(na_cols)!s}")
         df = df.drop(columns=na_cols)
 
     df.index.name = "date"
@@ -93,7 +95,7 @@ def join(df_target: pd.DataFrame, df_source: pd.DataFrame) -> pd.DataFrame:
     if not df_target.empty:
         check_new_data_in_range(df_source, df_target)
     print(
-        f"Adding new columns: {str(list(df_source.columns.difference(df_target.columns)))}"
+        f"Adding new columns: {list(df_source.columns.difference(df_target.columns))!s}"
     )
     return df_target.join(df_source) if not df_target.empty else df_source
 
@@ -102,12 +104,11 @@ DateLike: TypeAlias = datetime | date | pd.Timestamp
 
 
 def datelike_to_date(d: DateLike) -> date:
-    if isinstance(d, datetime) or isinstance(d, pd.Timestamp):
+    if isinstance(d, (datetime, pd.Timestamp)):
         return d.date()
-    elif isinstance(d, date):
+    if isinstance(d, date):
         return d
-    else:
-        raise ValueError(f"Invalid type for datelike: {type(d)}")
+    raise ValueError(f"Invalid type for datelike: {type(d)}")
 
 
 def check_new_data_in_range(df_source: pd.DataFrame, df_target: pd.DataFrame) -> None:

--- a/src/quantifiedme/derived/heartrate.py
+++ b/src/quantifiedme/derived/heartrate.py
@@ -39,11 +39,13 @@ def load_heartrate_minutes_df():
 
 
 def load_heartrate_summary_df(
-    zones={"resting": 0, "low": 100, "med": 140, "high": 160}, freq="D"
+    zones: dict[str, int] | None = None, freq="D"
 ) -> pd.DataFrame:
     """
     Load heartrates, group into freq, bin by zone, and return a dataframe.
     """
+    if zones is None:
+        zones = {"resting": 0, "low": 100, "med": 140, "high": 160}
     source_df = load_heartrate_minutes_df()
     df = pd.DataFrame()
     df["hr_mean"] = source_df["hr"].groupby(pd.Grouper(freq=freq)).mean()
@@ -52,7 +54,7 @@ def load_heartrate_summary_df(
     df_zones = pd.cut(
         source_df["hr"], bins=[*zones.values(), 300], labels=[*zones.keys()]
     )
-    for zone in zones.keys():
+    for zone in zones:
         df[f"hr_duration_{zone}"] = df_zones[df_zones == zone].groupby(
             pd.Grouper(freq=freq)
         ).count() * pd.Timedelta(minutes=1)

--- a/src/quantifiedme/derived/screentime.py
+++ b/src/quantifiedme/derived/screentime.py
@@ -114,12 +114,12 @@ def load_screentime(
     # Verify that no events are older than `since`
     print(f"Query start: {since}")
     print(f"Events start: {events[0].timestamp}")
-    assert all([since <= e.timestamp for e in events])
+    assert all(since <= e.timestamp for e in events)
 
     # Verify that no events take place in the future
     # FIXME: Doesn't work with fake data, atm
     if "fake" not in datasources:
-        assert all([e.timestamp + e.duration <= now for e in events])
+        assert all(e.timestamp + e.duration <= now for e in events)
 
     # Verify that no events overlap
     verify_no_overlap(events)
@@ -149,11 +149,10 @@ def load_screentime_cached(
         if since:
             events = [e for e in events if e.timestamp >= since]
         return events
-    else:
-        events = load_screentime(since=since, **kwargs)
-        with open(path, "wb") as f:
-            pickle.dump(events, f)
-        return events
+    events = load_screentime(since=since, **kwargs)
+    with open(path, "wb") as f:
+        pickle.dump(events, f)
+    return events
 
 
 def _join_events(

--- a/src/quantifiedme/derived/sleep.py
+++ b/src/quantifiedme/derived/sleep.py
@@ -35,10 +35,12 @@ def _merge_several_sleep_records_per_day(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def load_sleep_df(ignore: list[str] = [], aggregate=True) -> pd.DataFrame:
+def load_sleep_df(ignore: list[str] | None = None, aggregate=True) -> pd.DataFrame:
     """
     Loads sleep data from Fitbit, Oura, and Whoop into a single dataframe.
     """
+    if ignore is None:
+        ignore = []
     df: pd.DataFrame = pd.DataFrame()
 
     # Fitbit
@@ -78,8 +80,7 @@ def load_sleep_df(ignore: list[str] = [], aggregate=True) -> pd.DataFrame:
 def join(df_target, df_source, **kwargs) -> pd.DataFrame:
     if df_target.empty:
         return df_source
-    else:
-        return df_target.join(df_source, how="outer", **kwargs)
+    return df_target.join(df_source, how="outer", **kwargs)
 
 
 @click.command()

--- a/src/quantifiedme/load/activitywatch_fake.py
+++ b/src/quantifiedme/load/activitywatch_fake.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta
 
 import numpy as np
-
 from aw_core import Event
 
 fakedata_weights = [

--- a/src/quantifiedme/load/cronometer.py
+++ b/src/quantifiedme/load/cronometer.py
@@ -77,7 +77,9 @@ def load_servings_df(path: Path | None = None) -> pd.DataFrame:
     """
     if path is None:
         config = load_config()
-        path = Path(config["data"].get("cronometer_servings", config["data"]["cronometer"])).expanduser()
+        path = Path(
+            config["data"].get("cronometer_servings", config["data"]["cronometer"])
+        ).expanduser()
     else:
         path = Path(path).expanduser()
 

--- a/src/quantifiedme/load/eeg.py
+++ b/src/quantifiedme/load/eeg.py
@@ -30,7 +30,7 @@ bands_ordered = ["delta", "theta", "alpha", "beta", "gamma"]
 def load_data():
     filesets = load_fileset()
     df = pd.DataFrame()
-    for timestamp, files in filesets.items():
+    for files in filesets.values():
         result = load_session(files)
         # pprint(result)
         df = pd.concat([df, pd.DataFrame(result)], ignore_index=True)
@@ -57,7 +57,7 @@ def load_session(files: dict) -> dict:
 
     # we have to deal with the channels, such as CP3_alpha, CP3_beta, etc.
     # for now, we will just average them all together
-    channels, bands = zip(*[c.split("_") for c in df_pbb.columns])
+    channels, bands = zip(*[c.split("_") for c in df_pbb.columns], strict=False)
     channels, bands = tuple(set(channels)), tuple(set(bands))
 
     df = pd.DataFrame(index=df_pbb.index)

--- a/src/quantifiedme/load/fitbit.py
+++ b/src/quantifiedme/load/fitbit.py
@@ -19,9 +19,7 @@ def load_sleep_df() -> pd.DataFrame:
     files = filepath.glob("Global Export Data/sleep-*.json")
 
     # load each file into a dataframe
-    dfs = []
-    for f in sorted(files):
-        dfs.append(_load_sleep_file(f))
+    dfs = [_load_sleep_file(f) for f in sorted(files)]
 
     # combine all the dataframes into a single dataframe
     df = pd.concat(dfs)

--- a/src/quantifiedme/load/freestyle_libre.py
+++ b/src/quantifiedme/load/freestyle_libre.py
@@ -26,7 +26,7 @@ _HEADER_COL = "Device Timestamp"
 
 # Record type IDs in the Abbott export
 _RECORD_HISTORIC = 0  # automatic 15-min reading
-_RECORD_SCAN = 1      # manual scan
+_RECORD_SCAN = 1  # manual scan
 
 
 def load_glucose_df(
@@ -94,13 +94,21 @@ def load_glucose_df(
 
     if glucose_col_mmol:
         # EU export — values already in mmol/L
-        historic_col = next((c for c in df.columns if "Historic Glucose" in c and "mmol" in c), None)
-        scan_col = next((c for c in df.columns if "Scan Glucose" in c and "mmol" in c), None)
+        historic_col = next(
+            (c for c in df.columns if "Historic Glucose" in c and "mmol" in c), None
+        )
+        scan_col = next(
+            (c for c in df.columns if "Scan Glucose" in c and "mmol" in c), None
+        )
         factor = 1.0
     elif glucose_col_mgdl:
         # US export — convert mg/dL to mmol/L
-        historic_col = next((c for c in df.columns if "Historic Glucose" in c and "mg" in c), None)
-        scan_col = next((c for c in df.columns if "Scan Glucose" in c and "mg" in c), None)
+        historic_col = next(
+            (c for c in df.columns if "Historic Glucose" in c and "mg" in c), None
+        )
+        scan_col = next(
+            (c for c in df.columns if "Scan Glucose" in c and "mg" in c), None
+        )
         factor = 1 / 18.018
     else:
         raise ValueError(
@@ -181,7 +189,9 @@ def create_fake_glucose_df(
     import numpy as np
 
     rng = np.random.default_rng(seed)
-    timestamps = pd.date_range(start=start, end=end, freq=f"{interval_minutes}min", tz="UTC")
+    timestamps = pd.date_range(
+        start=start, end=end, freq=f"{interval_minutes}min", tz="UTC"
+    )
     n = len(timestamps)
 
     # Baseline ~5.5 mmol/L with diurnal variation and random walk noise

--- a/src/quantifiedme/load/google_activity.py
+++ b/src/quantifiedme/load/google_activity.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
+
 from quantifiedme.config import load_config
 
 

--- a/src/quantifiedme/load/home_assistant.py
+++ b/src/quantifiedme/load/home_assistant.py
@@ -191,7 +191,9 @@ def load_sensor_df_api(
     try:
         import requests  # type: ignore[import-untyped]
     except ImportError as e:
-        raise ImportError("requests is required for REST API access: pip install requests") from e
+        raise ImportError(
+            "requests is required for REST API access: pip install requests"
+        ) from e
 
     if start is None:
         start = datetime.now(tz=timezone.utc) - timedelta(days=1)
@@ -220,16 +222,15 @@ def load_sensor_df_api(
 
     # Response is a list of lists (one per entity) of state objects
     data = response.json()
-    rows = []
-    for entity_history in data:
-        for state_obj in entity_history:
-            rows.append(
-                {
-                    "entity_id": state_obj["entity_id"],
-                    "state": state_obj["state"],
-                    "last_updated": state_obj["last_updated"],
-                }
-            )
+    rows = [
+        {
+            "entity_id": state_obj["entity_id"],
+            "state": state_obj["state"],
+            "last_updated": state_obj["last_updated"],
+        }
+        for entity_history in data
+        for state_obj in entity_history
+    ]
 
     if not rows:
         return pd.DataFrame(columns=["entity_id", "state", "unit"]).set_index(
@@ -268,9 +269,24 @@ def create_fake_sensor_df(
     for i, ts in enumerate(dates):
         rows.extend(
             [
-                {"timestamp": ts, "entity_id": "sensor.temperature_bedroom", "state": temp[i], "unit": "°C"},
-                {"timestamp": ts, "entity_id": "sensor.humidity_bedroom", "state": humidity[i], "unit": "%"},
-                {"timestamp": ts, "entity_id": "sensor.co2_office", "state": co2[i], "unit": "ppm"},
+                {
+                    "timestamp": ts,
+                    "entity_id": "sensor.temperature_bedroom",
+                    "state": temp[i],
+                    "unit": "°C",
+                },
+                {
+                    "timestamp": ts,
+                    "entity_id": "sensor.humidity_bedroom",
+                    "state": humidity[i],
+                    "unit": "%",
+                },
+                {
+                    "timestamp": ts,
+                    "entity_id": "sensor.co2_office",
+                    "state": co2[i],
+                    "unit": "ppm",
+                },
             ]
         )
 

--- a/src/quantifiedme/load/qslang.py
+++ b/src/quantifiedme/load/qslang.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pint
-
 from qslang import Event
 from qslang.dose import ureg
 from qslang.main import load_events
@@ -44,7 +43,7 @@ class DuplicateFilter:
 def load_df(events: list[Event] | None = None) -> pd.DataFrame:
     if events is None:
         events = load_events()
-    events = [e for e in events]
+    events = list(events)
 
     with DuplicateFilter(logger):
         for e in events:
@@ -86,7 +85,7 @@ def load_df(events: list[Event] | None = None) -> pd.DataFrame:
                 "substance": e.data.get("substance"),
                 "dose": e.data.get("amount_pint") or 0,
                 # FIXME: Only supports one tag
-                "tag": list(sorted(e.data.get("tags") or {"none"}))[0],
+                "tag": sorted(e.data.get("tags") or {"none"})[0],
                 "data": e.data,
             }
             for e in events
@@ -113,7 +112,7 @@ def to_series(
     """
     assert tag or substance
     key = "tag" if tag else "substance"
-    val = tag if tag else substance
+    val = tag or substance
 
     # Filter for the tag/substance we want
     df = df[df[key] == val]
@@ -152,9 +151,9 @@ def load_daily_df(events: list[Event] | None = None) -> pd.DataFrame:
 
     substances = {s for s in df_src["substance"] if s}
     series_subst = {
-        subst.lower()
-        .replace("-", "")
-        .replace(" ", ""): to_series(df_src, substance=subst)
+        subst.lower().replace("-", "").replace(" ", ""): to_series(
+            df_src, substance=subst
+        )
         for subst in substances
     }
     df = pd.concat([df, pd.DataFrame(series_tags), pd.DataFrame(series_subst)], axis=1)

--- a/src/quantifiedme/load/smartertime.py
+++ b/src/quantifiedme/load/smartertime.py
@@ -18,7 +18,7 @@ def load_events(since: datetime) -> list[Event]:
     # TODO: allow loading directly from export, so we don't need to manually convert to aw-bucket json
     events_smartertime: list[Event] = []
     # TODO: underspecified hostname priority
-    for hostname, events in _load_smartertime_devices(since).items():
+    for events in _load_smartertime_devices(since).values():
         events_smartertime = union_no_overlap(events_smartertime, events)
     return events_smartertime
 
@@ -119,10 +119,9 @@ def import_to_awserver(bucket):
 def default(o):
     if hasattr(o, "isoformat"):
         return o.isoformat()
-    elif hasattr(o, "total_seconds"):
+    if hasattr(o, "total_seconds"):
         return o.total_seconds()
-    else:
-        raise NotImplementedError
+    raise NotImplementedError
 
 
 def convert_csv_to_awbucket(filepath):
@@ -132,8 +131,8 @@ def convert_csv_to_awbucket(filepath):
 
 
 if __name__ == "__main__":
-    assert len(sys.argv) > 2 and sys.argv[1] in [
-        "convert"
-    ], "Usage: smartertime.py convert <filename>"
+    assert len(sys.argv) > 2 and sys.argv[1] == "convert", (
+        "Usage: smartertime.py convert <filename>"
+    )
     filename = sys.argv.pop()
     convert_csv_to_awbucket(filename)

--- a/src/quantifiedme/load/toggl_.py
+++ b/src/quantifiedme/load/toggl_.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 try:
     from toggl import api
@@ -15,9 +15,8 @@ def load_toggl(start: datetime, stop: datetime) -> list[Event]:
     # The Toggl API has a query limit of 1 year
     if stop - start < timedelta(days=360):
         return _load_toggl(start, stop)
-    else:
-        split = stop - timedelta(days=360)
-        return load_toggl(start, split) + _load_toggl(split, stop)
+    split = stop - timedelta(days=360)
+    return load_toggl(start, split) + _load_toggl(split, stop)
 
 
 def _load_toggl(start: datetime, stop: datetime) -> list[Event]:
@@ -30,7 +29,7 @@ def _load_toggl(start: datetime, stop: datetime) -> list[Event]:
         workspaces = list(api.Workspace.objects.all())
         print(workspaces)
         print([w.id for w in workspaces])
-        print(f"Found {len(workspaces)} workspaces: {list(w.name for w in workspaces)}")
+        print(f"Found {len(workspaces)} workspaces: {[w.name for w in workspaces]}")
         entries: list[dict] = [
             e.to_dict()
             for workspace in workspaces

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -61,7 +61,9 @@ def load_sleep_df() -> pd.DataFrame:
 
     # set index and sort
     offset = timedelta(hours=8)
-    df = df.set_index(pd.to_datetime(pd.DatetimeIndex(df["start"] - offset).date, utc=True))  # type: ignore
+    df = df.set_index(
+        pd.to_datetime(pd.DatetimeIndex(df["start"] - offset).date, utc=True)
+    )  # type: ignore
     df = df.sort_index()
 
     # rename index to timestamp

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -62,8 +62,8 @@ def load_sleep_df() -> pd.DataFrame:
     # set index and sort
     offset = timedelta(hours=8)
     df = df.set_index(
-        pd.to_datetime(pd.DatetimeIndex(df["start"] - offset).date, utc=True)
-    )  # type: ignore
+        pd.to_datetime(pd.DatetimeIndex(df["start"] - offset).date, utc=True)  # type: ignore[arg-type]
+    )
     df = df.sort_index()
 
     # rename index to timestamp

--- a/src/quantifiedme/main.py
+++ b/src/quantifiedme/main.py
@@ -1,9 +1,9 @@
 import click
 
 from .derived.all_df import all_df
+from .derived.heartrate import heartrate
 from .derived.screentime import screentime
 from .derived.sleep import sleep
-from .derived.heartrate import heartrate
 from .load.habitbull import habits
 from .load.location import locate
 from .load.oura import oura
@@ -13,7 +13,6 @@ from .load.qslang import main as qslang
 @click.group()
 def main():
     """QuantifiedMe is a tool to help you track your life"""
-    pass
 
 
 for subcmd in [locate, habits, oura, screentime, all_df, sleep, heartrate]:

--- a/src/quantifiedme/timelineplot/plot.py
+++ b/src/quantifiedme/timelineplot/plot.py
@@ -1,15 +1,15 @@
 import sys
-from typing import TypeVar, Union
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import TypeVar
 
 import matplotlib.pyplot as plt
 
 from .util import take_until_next
 
 T = TypeVar("T")
-Color = Union[str | tuple[float, float, float]]
+Color = str | tuple[float, float, float]
 Index = TypeVar("Index", int, datetime)
 Limits = tuple[Index, Index]
 Event = tuple[Limits, Color, str]
@@ -45,12 +45,10 @@ class TimelineFigure:
 
         # Check that type assumption is true
         assert all(
-            [
-                isinstance(event[0][0], type(index_example))
-                and isinstance(event[0][1], type(index_example))
-                for bar in self.bars
-                for event in bar.events
-            ]
+            isinstance(event[0][0], type(index_example))
+            and isinstance(event[0][1], type(index_example))
+            for bar in self.bars
+            for event in bar.events
         )
 
         for bar_idx, bar in enumerate(self.bars):

--- a/src/quantifiedme/timelineplot/util.py
+++ b/src/quantifiedme/timelineplot/util.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator, Iterable
 from typing import TypeVar
-from collections.abc import Iterable, Generator
 
 T = TypeVar("T")
 
@@ -28,4 +28,4 @@ def take_until_next(
 
 def test_take_until_next():
     ls = [1, 1, 1, 2, 3, 3]
-    assert [((0, 2), 1), ((3, 3), 2), ((4, 5), 3)] == list(take_until_next(ls))
+    assert list(take_until_next(ls)) == [((0, 2), 1), ((3, 3), 2), ((4, 5), 3)]

--- a/src/quantifiedme/ui/__main__.py
+++ b/src/quantifiedme/ui/__main__.py
@@ -1,5 +1,4 @@
 from quantifiedme.ui.main import main
 
-
 if __name__ == "__main__":
     main()

--- a/src/quantifiedme/ui/main.py
+++ b/src/quantifiedme/ui/main.py
@@ -4,6 +4,7 @@ from functools import cache
 import calplot
 import gradio as gr
 import pandas as pd
+
 from quantifiedme.derived.all_df import load_all_df
 from quantifiedme.derived.sleep import load_sleep_df
 from quantifiedme.load.qslang import load_daily_df as load_qslang_daily_df


### PR DESCRIPTION
## Summary

Follows up on Erik's request in #11 to enable all the ruff rules from gptme's `pyproject.toml`.

- Adds `[tool.ruff]` and `[tool.ruff.lint]` config matching gptme's rule set (bugbear, pyupgrade, isort, comprehensions, refurb, perflint, simplify, type-checking, etc.)
- Fixes all 72 lint issues found (22 auto-fixed, rest manually fixed)
- DTZ (timezone-aware datetime) rules deferred — they'd require careful data pipeline changes

### Rules enabled
`E4/E7/E9`, `F`, `B`, `UP`, `I`, `C4`, `FURB`, `FLY`, `ISC`, `PLE`, `PERF`, `SIM`, `PIE`, `RET`, `RUF`, `TC`, `DTZ` (ignored for now)

### Notable fixes
- Mutable default arguments (`[] → None` + init)
- Unused loop variables → `.values()`
- Unnecessary comprehensions/generators
- `Union[X | Y]` → `X | Y`
- `key in dict.keys()` → `key in dict`

## Test plan
- [x] `ruff check src/` passes with zero errors
- [x] `ruff format --check src/` passes
- [ ] Existing tests still pass (need poetry env to verify)

## Summary by Sourcery

Enable Ruff linting configuration aligned with the project’s target rule set and update existing code to satisfy the new lint rules.

Enhancements:
- Add Ruff lint configuration to pyproject.toml, including selected rule families and isort settings for first-party imports.
- Refactor multiple modules to address lint findings, including safer defaults, simplified control flow, and more idiomatic use of comprehensions and type hints.
- Clean up minor style and readability issues across loaders, derived data utilities, and plotting helpers without changing core behavior.