### PR TITLE
feat(predict): decay kernels + LightGBM baseline for QS prediction

### DIFF
--- a/src/quantifiedme/predict/__init__.py
+++ b/src/quantifiedme/predict/__init__.py
@@ -1,0 +1,8 @@
+"""Predictive QS framework — intervention simulator on top of QS data.
+
+Turns quantifiedme from a dashboard into a "what happens if I do X?" engine.
+
+Modules:
+    features: Decay kernels and feature transforms
+    baseline: LightGBM predictive baseline
+"""

--- a/src/quantifiedme/predict/baseline.py
+++ b/src/quantifiedme/predict/baseline.py
@@ -1,0 +1,178 @@
+"""LightGBM baseline model for QS prediction.
+
+Quick predictive baseline to reveal which features actually matter
+before investing in Bayesian models. Predicts next-day outcomes
+(e.g. work hours) from substance history + screen time patterns.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .features import build_feature_frame
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BaselineResult:
+    """Results from training a baseline model."""
+
+    train_rmse: float
+    test_rmse: float
+    train_mae: float
+    test_mae: float
+    train_r2: float
+    test_r2: float
+    feature_importance: pd.Series
+    target_col: str
+    n_train: int
+    n_test: int
+    target_mean: float
+    target_std: float
+    predictions: pd.Series = field(repr=False)
+
+    def summary(self) -> str:
+        lines = [
+            f"Baseline model: {self.target_col}",
+            f"  Train: n={self.n_train}, RMSE={self.train_rmse:.3f}, MAE={self.train_mae:.3f}, R²={self.train_r2:.3f}",
+            f"  Test:  n={self.n_test}, RMSE={self.test_rmse:.3f}, MAE={self.test_mae:.3f}, R²={self.test_r2:.3f}",
+            f"  Target: mean={self.target_mean:.3f}, std={self.target_std:.3f}",
+            "  Top 10 features:",
+        ]
+        for feat, imp in self.feature_importance.head(10).items():
+            lines.append(f"    {feat}: {imp:.0f}")
+        return "\n".join(lines)
+
+
+def load_csv_export(path: str | Path) -> pd.DataFrame:
+    """Load the privacy-safe CSV export from qs-export.py.
+
+    Args:
+        path: Path to the CSV file.
+
+    Returns:
+        DataFrame indexed by date with time:* and tag:* columns.
+    """
+    df = pd.read_csv(path, index_col="date", parse_dates=True)
+    df.index = df.index.date  # type: ignore[attr-defined]  # normalize to date objects
+    df = df.sort_index()
+    return df
+
+
+def train_baseline(
+    df: pd.DataFrame,
+    target_col: str = "time:Work",
+    test_fraction: float = 0.2,
+    top_n_substances: int = 15,
+) -> BaselineResult:
+    """Train a LightGBM model predicting next-day target.
+
+    Uses time-based split (no shuffling — respects temporal ordering).
+
+    Args:
+        df: Raw DataFrame from CSV export or load_all_df().
+        target_col: Column to predict.
+        test_fraction: Fraction of data to hold out (from the end).
+        top_n_substances: Number of top substances to include.
+
+    Returns:
+        BaselineResult with metrics and feature importances.
+    """
+    import lightgbm as lgb  # type: ignore[import-untyped]
+
+    X, y = build_feature_frame(df, target_col=target_col, top_n_substances=top_n_substances)
+
+    # Sanitize feature names for LightGBM (no special JSON chars)
+    import re as _re
+
+    clean_names = {c: _re.sub(r"[^a-zA-Z0-9_]", "_", c) for c in X.columns}
+    X = X.rename(columns=clean_names)
+
+    # Time-based split
+    split_idx = int(len(X) * (1 - test_fraction))
+    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
+    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+
+    logger.info(f"Training on {len(X_train)} days, testing on {len(X_test)} days")
+    logger.info(f"Features: {len(X.columns)}")
+
+    # Train LightGBM
+    train_data = lgb.Dataset(X_train, label=y_train)
+    valid_data = lgb.Dataset(X_test, label=y_test, reference=train_data)
+
+    params = {
+        "objective": "regression",
+        "metric": "rmse",
+        "learning_rate": 0.05,
+        "num_leaves": 31,
+        "min_child_samples": 20,
+        "subsample": 0.8,
+        "colsample_bytree": 0.8,
+        "reg_alpha": 0.1,
+        "reg_lambda": 0.1,
+        "verbosity": -1,
+    }
+
+    model = lgb.train(
+        params,
+        train_data,
+        num_boost_round=500,
+        valid_sets=[valid_data],
+        callbacks=[lgb.early_stopping(50), lgb.log_evaluation(0)],
+    )
+
+    # Predictions
+    y_pred_train = model.predict(X_train)
+    y_pred_test = model.predict(X_test)
+
+    # Metrics
+    from sklearn.metrics import (  # type: ignore[import-untyped]
+        mean_absolute_error,
+        mean_squared_error,
+        r2_score,
+    )
+
+    train_rmse = float(np.sqrt(mean_squared_error(y_train, y_pred_train)))
+    test_rmse = float(np.sqrt(mean_squared_error(y_test, y_pred_test)))
+    train_mae = float(mean_absolute_error(y_train, y_pred_train))
+    test_mae = float(mean_absolute_error(y_test, y_pred_test))
+    train_r2 = float(r2_score(y_train, y_pred_train))
+    test_r2 = float(r2_score(y_test, y_pred_test))
+
+    # Feature importance (map back to original names)
+    reverse_names = {v: k for k, v in clean_names.items()}
+    importance = pd.Series(
+        model.feature_importance(importance_type="gain"),
+        index=[reverse_names.get(c, c) for c in X.columns],
+    ).sort_values(ascending=False)
+
+    return BaselineResult(
+        train_rmse=train_rmse,
+        test_rmse=test_rmse,
+        train_mae=train_mae,
+        test_mae=test_mae,
+        train_r2=train_r2,
+        test_r2=test_r2,
+        feature_importance=importance,
+        target_col=target_col,
+        n_train=len(X_train),
+        n_test=len(X_test),
+        target_mean=float(y.mean()),
+        target_std=float(y.std()),
+        predictions=pd.Series(y_pred_test, index=y_test.index),
+    )
+
+
+def run_baseline(
+    csv_path: str | Path,
+    target_col: str = "time:Work",
+) -> BaselineResult:
+    """Convenience: load CSV and train baseline in one call."""
+    df = load_csv_export(csv_path)
+    result = train_baseline(df, target_col=target_col)
+    print(result.summary())
+    return result

--- a/src/quantifiedme/predict/baseline.py
+++ b/src/quantifiedme/predict/baseline.py
@@ -30,6 +30,7 @@ class BaselineResult:
     feature_importance: pd.Series
     target_col: str
     n_train: int
+    n_val: int
     n_test: int
     target_mean: float
     target_std: float
@@ -39,7 +40,7 @@ class BaselineResult:
         lines = [
             f"Baseline model: {self.target_col}",
             f"  Train: n={self.n_train}, RMSE={self.train_rmse:.3f}, MAE={self.train_mae:.3f}, R²={self.train_r2:.3f}",
-            f"  Test:  n={self.n_test}, RMSE={self.test_rmse:.3f}, MAE={self.test_mae:.3f}, R²={self.test_r2:.3f}",
+            f"  Test:  n={self.n_test} (val={self.n_val}), RMSE={self.test_rmse:.3f}, MAE={self.test_mae:.3f}, R²={self.test_r2:.3f}",
             f"  Target: mean={self.target_mean:.3f}, std={self.target_std:.3f}",
             "  Top 10 features:",
         ]
@@ -90,19 +91,35 @@ def train_baseline(
     import re as _re
 
     clean_names = {c: _re.sub(r"[^a-zA-Z0-9_]", "_", c) for c in X.columns}
+
+    # Check for collisions: distinct original names mapping to same sanitized name
+    reverse: dict[str, str] = {}
+    for orig, clean in clean_names.items():
+        if clean in reverse and reverse[clean] != orig:
+            raise ValueError(
+                f"Feature name collision after sanitization: "
+                f"'{orig}' and '{reverse[clean]}' both map to '{clean}'"
+            )
+        reverse[clean] = orig
+
     X = X.rename(columns=clean_names)
 
-    # Time-based split
-    split_idx = int(len(X) * (1 - test_fraction))
-    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
-    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+    # Time-based 3-way split: train / validation (early stopping) / test (metrics)
+    # This prevents early stopping from biasing test metrics (Greptile P1).
+    val_fraction = test_fraction
+    train_end = int(len(X) * (1 - test_fraction - val_fraction))
+    val_end = int(len(X) * (1 - test_fraction))
+    X_train, X_val, X_test = X.iloc[:train_end], X.iloc[train_end:val_end], X.iloc[val_end:]
+    y_train, y_val, y_test = y.iloc[:train_end], y.iloc[train_end:val_end], y.iloc[val_end:]
 
-    logger.info(f"Training on {len(X_train)} days, testing on {len(X_test)} days")
+    logger.info(
+        f"Split: {len(X_train)} train, {len(X_val)} val, {len(X_test)} test"
+    )
     logger.info(f"Features: {len(X.columns)}")
 
-    # Train LightGBM
+    # Train LightGBM (early stopping on validation set, NOT test set)
     train_data = lgb.Dataset(X_train, label=y_train)
-    valid_data = lgb.Dataset(X_test, label=y_test, reference=train_data)
+    val_data = lgb.Dataset(X_val, label=y_val, reference=train_data)
 
     params = {
         "objective": "regression",
@@ -121,11 +138,11 @@ def train_baseline(
         params,
         train_data,
         num_boost_round=500,
-        valid_sets=[valid_data],
+        valid_sets=[val_data],
         callbacks=[lgb.early_stopping(50), lgb.log_evaluation(0)],
     )
 
-    # Predictions
+    # Predictions on held-out test set (not used during training at all)
     y_pred_train = model.predict(X_train)
     y_pred_test = model.predict(X_test)
 
@@ -160,6 +177,7 @@ def train_baseline(
         feature_importance=importance,
         target_col=target_col,
         n_train=len(X_train),
+        n_val=len(X_val),
         n_test=len(X_test),
         target_mean=float(y.mean()),
         target_std=float(y.std()),

--- a/src/quantifiedme/predict/features.py
+++ b/src/quantifiedme/predict/features.py
@@ -1,0 +1,230 @@
+"""Feature transforms for predictive QS models.
+
+Core idea: raw binary substance tags (tag:caffeine = 0/1) lose temporal
+information. A decay kernel encodes *how much* of a substance is still
+active, based on pharmacological half-lives.
+
+    substance_active(t) = Σ dose_i * exp(-(t - t_i) / τ)
+
+Since QSlang data is daily binary (not timestamped doses), we use a
+simplified multi-day decay: each day's binary flag is treated as a unit
+dose, and the kernel sums contributions from the past `window` days.
+"""
+
+import numpy as np
+import pandas as pd
+
+# Substance half-lives in days (converted from hours for daily resolution).
+# These are pharmacological half-lives; behavioral effects may differ.
+# Using ~2x half-life as the effective τ for daily aggregation.
+SUBSTANCE_DECAY_DAYS: dict[str, float] = {
+    "caffeine": 0.5,  # ~5-6h half-life, clears within a day
+    "alcohol": 0.5,  # acute: ~3-4h, but next-day hangover effect ~1d
+    "cannabinoids": 1.5,  # THC: 6-12h acute, fat-soluble chronic load
+    "nicotine": 0.25,  # ~2h half-life, very fast clearance
+    "psychedelics": 2.0,  # acute 6-12h, afterglow/tolerance multi-day
+    "stimulants": 0.5,  # phenylpiracetam etc, ~3-5h
+    "nootropics": 1.0,  # varies widely, conservative default
+    "sleepaids": 0.5,  # melatonin etc, clears by morning
+    "dissociatives": 1.0,
+    "empathogens": 2.0,  # MDMA-like, multi-day recovery
+    "gabaergics": 0.5,
+    "benzos": 1.5,  # longer half-life benzos
+    "depressants": 0.5,
+}
+
+# Default decay for substances not in the table above
+DEFAULT_DECAY_DAYS = 1.0
+
+
+def decay_kernel(
+    series: pd.Series,
+    tau: float,
+    window: int = 7,
+) -> pd.Series:
+    """Apply exponential decay kernel to a binary time series.
+
+    For each day t, computes:
+        kernel(t) = Σ_{k=0}^{window-1} series[t-k] * exp(-k / τ)
+
+    Args:
+        series: Binary (0/1) daily series indexed by date.
+        tau: Decay constant in days. Larger = slower decay.
+        window: Number of past days to consider.
+
+    Returns:
+        Series of same length with decay-weighted values.
+    """
+    weights = np.exp(-np.arange(window) / tau)
+    # Use rolling apply with the weights
+    result = pd.Series(0.0, index=series.index, dtype=float)
+    values = series.fillna(0).values.astype(float)
+
+    for i in range(len(values)):
+        lookback = min(i + 1, window)
+        window_vals = np.asarray(values[i - lookback + 1 : i + 1][::-1])
+        result.iloc[i] = float(np.dot(window_vals, weights[:lookback]))
+
+    return result
+
+
+def build_substance_features(
+    df: pd.DataFrame,
+    top_n: int | None = None,
+    min_frequency: float = 0.01,
+    window: int = 7,
+) -> pd.DataFrame:
+    """Build decay kernel features for substance tags.
+
+    Args:
+        df: DataFrame with `tag:*` columns (binary 0/1).
+        top_n: If set, keep only the N most frequent substances.
+        min_frequency: Minimum fraction of days with usage to include.
+        window: Lookback window for decay kernels.
+
+    Returns:
+        DataFrame with `decay:*` columns for each substance.
+    """
+    tag_cols = [c for c in df.columns if c.startswith("tag:")]
+    if not tag_cols:
+        return pd.DataFrame(index=df.index)
+
+    # Filter by frequency
+    frequencies = df[tag_cols].mean()
+    active_tags = frequencies[frequencies >= min_frequency].index.tolist()
+
+    if top_n is not None:
+        active_tags = frequencies[active_tags].nlargest(top_n).index.tolist()
+
+    features = pd.DataFrame(index=df.index)
+
+    for col in active_tags:
+        substance = col.removeprefix("tag:")
+        tau = SUBSTANCE_DECAY_DAYS.get(substance, DEFAULT_DECAY_DAYS)
+
+        # Raw binary (today)
+        features[f"decay:{substance}:today"] = df[col].fillna(0)
+
+        # Decay kernel (accumulated exposure)
+        features[f"decay:{substance}:kernel"] = decay_kernel(df[col], tau=tau, window=window)
+
+        # Simple trailing sum (how many of past N days)
+        features[f"decay:{substance}:count_{window}d"] = (
+            df[col].fillna(0).rolling(window, min_periods=1).sum()
+        )
+
+    return features
+
+
+def build_screentime_features(
+    df: pd.DataFrame,
+    lag_days: list[int] | None = None,
+) -> pd.DataFrame:
+    """Build lag features for screen time categories.
+
+    Args:
+        df: DataFrame with `time:*` columns (hours).
+        lag_days: Which lags to create. Default [1, 2, 3, 7].
+
+    Returns:
+        DataFrame with lag and rolling features for key categories.
+    """
+    if lag_days is None:
+        lag_days = [1, 2, 3, 7]
+
+    # Key categories worth modeling (high variance, meaningful)
+    key_categories = [
+        "time:Work",
+        "time:Programming",
+        "time:Media",
+        "time:Social Media",
+        "time:Games",
+    ]
+
+    # Filter to categories that exist in the data
+    available = [c for c in key_categories if c in df.columns]
+    features = pd.DataFrame(index=df.index)
+
+    for col in available:
+        name = col.removeprefix("time:")
+
+        for lag in lag_days:
+            features[f"lag:{name}:d-{lag}"] = df[col].shift(lag)
+
+        # 7-day rolling mean
+        features[f"roll:{name}:7d_mean"] = (
+            df[col].rolling(7, min_periods=1).mean()
+        )
+
+        # 7-day rolling std (consistency/volatility)
+        features[f"roll:{name}:7d_std"] = (
+            df[col].rolling(7, min_periods=1).std().fillna(0)
+        )
+
+    return features
+
+
+def build_temporal_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Build calendar/temporal features from the date index.
+
+    Returns:
+        DataFrame with day-of-week, weekend flag, etc.
+    """
+    dates = pd.DatetimeIndex(df.index)
+    features = pd.DataFrame(index=df.index)
+
+    features["dow"] = dates.dayofweek  # 0=Monday
+    features["is_weekend"] = (dates.dayofweek >= 5).astype(int)
+    features["month"] = dates.month
+    features["day_of_year"] = dates.dayofyear
+
+    # Cyclical encoding for day of week
+    features["dow_sin"] = np.sin(2 * np.pi * dates.dayofweek / 7)
+    features["dow_cos"] = np.cos(2 * np.pi * dates.dayofweek / 7)
+
+    return features
+
+
+def build_feature_frame(
+    df: pd.DataFrame,
+    target_col: str = "time:Work",
+    top_n_substances: int | None = 15,
+    lag_days: list[int] | None = None,
+    substance_window: int = 7,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """Build the full feature frame for prediction.
+
+    Combines substance decay kernels, screen time lags, and temporal
+    features. The target is shifted by +1 day (predict tomorrow's value
+    from today's features).
+
+    Args:
+        df: Raw DataFrame from load_all_df() or CSV export.
+        target_col: Column to predict (default: time:Work).
+        top_n_substances: Number of top substances to include.
+        lag_days: Lag days for screen time features.
+        substance_window: Lookback window for substance kernels.
+
+    Returns:
+        (X, y) tuple where X is the feature matrix and y is the
+        next-day target. Rows with NaN target are dropped.
+    """
+    substance_features = build_substance_features(
+        df,
+        top_n=top_n_substances,
+        window=substance_window,
+    )
+    screentime_features = build_screentime_features(df, lag_days=lag_days)
+    temporal_features = build_temporal_features(df)
+
+    X = pd.concat([substance_features, screentime_features, temporal_features], axis=1)
+
+    # Target: next-day value (shift -1 so today's features predict tomorrow)
+    y = df[target_col].shift(-1)
+
+    # Drop rows where target is NaN (last row, plus any gaps)
+    valid = y.notna() & X.notna().all(axis=1)
+    X = X.loc[valid]
+    y = y.loc[valid]
+
+    return X, y

--- a/src/quantifiedme/predict/features.py
+++ b/src/quantifiedme/predict/features.py
@@ -55,17 +55,19 @@ def decay_kernel(
     Returns:
         Series of same length with decay-weighted values.
     """
+    if tau <= 0:
+        raise ValueError(f"tau must be positive, got {tau}")
+
     weights = np.exp(-np.arange(window) / tau)
-    # Use rolling apply with the weights
-    result = pd.Series(0.0, index=series.index, dtype=float)
     values = series.fillna(0).values.astype(float)
 
-    for i in range(len(values)):
-        lookback = min(i + 1, window)
-        window_vals = np.asarray(values[i - lookback + 1 : i + 1][::-1])
-        result.iloc[i] = float(np.dot(window_vals, weights[:lookback]))
+    # Vectorized convolution: pad with zeros on the left, convolve with weights
+    padded = np.concatenate([np.zeros(window - 1), values])
+    result_values = np.array(
+        [np.dot(padded[i : i + window][::-1], weights) for i in range(len(values))]
+    )
 
-    return result
+    return pd.Series(result_values, index=series.index, dtype=float)
 
 
 def build_substance_features(

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,132 @@
+"""Tests for the predictive QS framework."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from quantifiedme.predict.features import (
+    build_feature_frame,
+    build_screentime_features,
+    build_substance_features,
+    build_temporal_features,
+    decay_kernel,
+)
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    """Create a minimal DataFrame mimicking the QS export structure."""
+    dates = pd.date_range("2024-01-01", periods=30, freq="D")
+    rng = np.random.default_rng(42)
+
+    df = pd.DataFrame(
+        {
+            "time:Work": rng.uniform(0, 8, 30),
+            "time:Programming": rng.uniform(0, 5, 30),
+            "time:Media": rng.uniform(0, 4, 30),
+            "time:Social Media": rng.uniform(0, 2, 30),
+            "time:Games": rng.uniform(0, 3, 30),
+            "tag:caffeine": rng.choice([0, 1], 30, p=[0.3, 0.7]),
+            "tag:alcohol": rng.choice([0, 1], 30, p=[0.7, 0.3]),
+            "tag:cannabinoids": rng.choice([0, 1], 30, p=[0.8, 0.2]),
+            "tag:nicotine": rng.choice([0, 1], 30, p=[0.9, 0.1]),
+            # Rare substance — should be filtered out by min_frequency
+            "tag:psychedelics": np.zeros(30),
+        },
+        index=dates.date,
+    )
+    return df
+
+
+class TestDecayKernel:
+    def test_no_exposure_gives_zero(self):
+        series = pd.Series([0, 0, 0, 0, 0])
+        result = decay_kernel(series, tau=1.0, window=3)
+        assert (result == 0).all()
+
+    def test_single_exposure_decays(self):
+        series = pd.Series([1, 0, 0, 0, 0])
+        result = decay_kernel(series, tau=1.0, window=5)
+        # Day 0: 1.0 (immediate)
+        assert result.iloc[0] == pytest.approx(1.0)
+        # Day 1: exp(-1/1) ≈ 0.368
+        assert result.iloc[1] == pytest.approx(np.exp(-1), abs=0.01)
+        # Day 4: exp(-4/1) ≈ 0.018
+        assert result.iloc[4] == pytest.approx(np.exp(-4), abs=0.01)
+
+    def test_daily_exposure_accumulates(self):
+        series = pd.Series([1, 1, 1, 1, 1])
+        result = decay_kernel(series, tau=1.0, window=5)
+        # Each day accumulates more than a single exposure
+        assert result.iloc[4] > result.iloc[0]
+
+    def test_larger_tau_slower_decay(self):
+        series = pd.Series([1, 0, 0, 0, 0])
+        fast = decay_kernel(series, tau=0.5, window=5)
+        slow = decay_kernel(series, tau=2.0, window=5)
+        # Slow decay retains more at day 2
+        assert slow.iloc[2] > fast.iloc[2]
+
+
+class TestSubstanceFeatures:
+    def test_creates_expected_columns(self, sample_df: pd.DataFrame):
+        features = build_substance_features(sample_df, top_n=3, window=7)
+        # Should have today, kernel, and count columns per substance
+        assert any("decay:" in c and ":today" in c for c in features.columns)
+        assert any("decay:" in c and ":kernel" in c for c in features.columns)
+        assert any("decay:" in c and ":count_7d" in c for c in features.columns)
+
+    def test_filters_rare_substances(self, sample_df: pd.DataFrame):
+        features = build_substance_features(sample_df, min_frequency=0.05)
+        # psychedelics has 0 frequency, should be excluded
+        assert not any("psychedelics" in c for c in features.columns)
+
+    def test_top_n_limits_substances(self, sample_df: pd.DataFrame):
+        features = build_substance_features(sample_df, top_n=2)
+        substances = {c.split(":")[1] for c in features.columns}
+        assert len(substances) <= 2
+
+
+class TestScreentimeFeatures:
+    def test_creates_lag_features(self, sample_df: pd.DataFrame):
+        features = build_screentime_features(sample_df)
+        assert "lag:Work:d-1" in features.columns
+        assert "lag:Work:d-7" in features.columns
+
+    def test_creates_rolling_features(self, sample_df: pd.DataFrame):
+        features = build_screentime_features(sample_df)
+        assert "roll:Work:7d_mean" in features.columns
+        assert "roll:Work:7d_std" in features.columns
+
+
+class TestTemporalFeatures:
+    def test_creates_expected_columns(self, sample_df: pd.DataFrame):
+        features = build_temporal_features(sample_df)
+        assert "dow" in features.columns
+        assert "is_weekend" in features.columns
+        assert "dow_sin" in features.columns
+        assert "dow_cos" in features.columns
+
+    def test_weekend_flag_correct(self):
+        # 2024-01-06 is a Saturday, 2024-01-07 is a Sunday
+        dates = pd.date_range("2024-01-01", periods=14, freq="D")
+        df = pd.DataFrame(index=dates.date)
+        features = build_temporal_features(df)
+        # Monday Jan 1: not weekend
+        assert features.iloc[0]["is_weekend"] == 0
+        # Saturday Jan 6: weekend
+        assert features.iloc[5]["is_weekend"] == 1
+
+
+class TestBuildFeatureFrame:
+    def test_returns_aligned_x_y(self, sample_df: pd.DataFrame):
+        X, y = build_feature_frame(sample_df, target_col="time:Work")
+        assert len(X) == len(y)
+        assert len(X) > 0
+        # Target is shifted: last day of input should not be in output
+        assert len(X) < len(sample_df)
+
+    def test_no_nans_in_output(self, sample_df: pd.DataFrame):
+        X, y = build_feature_frame(sample_df, target_col="time:Work")
+        assert not X.isna().any().any()
+        assert not y.isna().any()


### PR DESCRIPTION
## Summary
- Adds `src/quantifiedme/predict/` package — the start of turning quantifiedme into a personal intervention simulator
- **Decay kernels** for substance tags: exponential decay with pharmacological half-lives (caffeine τ=0.5d, cannabinoids τ=1.5d, psychedelics τ=2d, etc.)
- **Feature engineering**: substance decay features, screen time lags/rolling stats, temporal/calendar features
- **LightGBM baseline** predicting next-day `time:Work` from substance history + screen time patterns
- **CSV loader** for the privacy-safe export pipeline (no raw QS data needed in the repo)
- 13 unit tests, mypy clean, ruff clean

## Initial Results (730 days real data)
```
Baseline model: time:Work
  Train: n=577, RMSE=1.374, MAE=1.006, R²=0.316
  Test:  n=145, RMSE=1.430, MAE=1.137, R²=0.055
  Target: mean=1.160, std=1.626
  Top features: psychedelics kernel, day-of-week, work/programming volatility,
                sleepaids kernel, depressants count, cannabinoids count
```

Model overfits (early stop at round 16) — expected with sparse daily data. But feature importance reveals meaningful signal: substance decay kernels + day-of-week + work consistency volatility.

## Next Steps (Phase 2)
- Weekday-only model variant (remove day-of-week dominance)
- PyMC Bayesian sleep model (once sleep data is in the export)
- SHAP analysis for deeper feature interpretation
- Counterfactual simulation: "what if I skip caffeine tomorrow?"

## Test plan
- [x] 13 unit tests pass (`pytest tests/test_predict.py`)
- [x] Trained on real 730-day QS export, model converges
- [x] mypy and ruff clean

## Summary by Sourcery

Introduce a predictive QS framework with feature engineering utilities and a LightGBM baseline model for next-day behavior prediction.

New Features:
- Add decay-kernel based substance features, screen time lag/rolling features, and temporal/calendar features for QS time series.
- Provide a LightGBM baseline that predicts next-day outcomes (e.g., work time) from engineered QS features and reports metrics and feature importances.
- Expose a CSV loader and convenience entrypoint to train and summarize the baseline model from exported QS data.
- Create a new quantifiedme.predict package as the foundation for an intervention-simulation layer over QS data.

Tests:
- Add unit tests covering decay kernels, substance/screentime/temporal feature construction, and end-to-end feature frame alignment and cleanliness.