### PR TITLE
feat(load/whoop): support new standard CSV export format + journal entries

### DIFF
--- a/src/quantifiedme/derived/all_df.py
+++ b/src/quantifiedme/derived/all_df.py
@@ -15,13 +15,14 @@ from aw_core import Event
 
 from ..load.location import load_daily_df as load_location_daily_df
 from ..load.qslang import load_daily_df as load_drugs_df
+from ..load.whoop import load_journal_daily_df as load_whoop_journal_daily_df
 from .heartrate import load_heartrate_summary_df
 from .screentime import load_category_df, load_screentime_cached
 from .sleep import load_sleep_df
 
 logger = logging.getLogger(__name__)
 
-Sources = Literal["screentime", "heartrate", "drugs", "location", "sleep"]
+Sources = Literal["screentime", "heartrate", "drugs", "location", "sleep", "journal"]
 
 
 def load_all_df(
@@ -75,6 +76,21 @@ def load_all_df(
         df_sleep = load_sleep_df()
         df_sleep.index = df_sleep.index.date  # type: ignore
         df = join(df, df_sleep.add_prefix("sleep:"))
+
+    if "journal" not in ignore:
+        print("\n# Adding journal (Whoop self-reports)")
+        # include_notes defaults to False — free-text notes are excluded for
+        # privacy. Pass include_notes=True via the loader directly if needed.
+        try:
+            df_journal = load_whoop_journal_daily_df()
+        except (FileNotFoundError, NotImplementedError, KeyError) as e:
+            # Journal source is optional: only ships in the standard Whoop
+            # export, and may not be configured at all. KeyError is raised
+            # by _whoop_dir when the config has no `data.whoop` entry.
+            logger.warning(f"Skipping journal source: {e}")
+        else:
+            df_journal.index = df_journal.index.date  # type: ignore
+            df = join(df, df_journal.add_prefix("journal:"))
 
     print()
 

--- a/src/quantifiedme/derived/heartrate.py
+++ b/src/quantifiedme/derived/heartrate.py
@@ -19,9 +19,15 @@ def load_heartrate_df() -> pd.DataFrame:
     dfs.append(fitbit_df)
 
     print("# Loading Whoop heartrate data")
-    whoop_df = whoop.load_heartrate_df()
-    whoop_df["source"] = "whoop"
-    dfs.append(whoop_df)
+    try:
+        whoop_df = whoop.load_heartrate_df()
+    except NotImplementedError as e:
+        # Standard Whoop CSV export ships only daily HR (cycles), not per-minute.
+        # Skip granular HR cleanly so the rest of the pipeline still runs.
+        print(f"  Skipped: {e}")
+    else:
+        whoop_df["source"] = "whoop"
+        dfs.append(whoop_df)
 
     df = pd.concat(dfs)
     df = df.sort_index()

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -1,72 +1,424 @@
 """
-Loads Whoop data
+Loads Whoop data.
 
-Requires the full GDPR-compliant export (which includes granular HR data), which is available at: https://privacy.whoop.com/
+Supports two export formats:
+
+- **Standard CSV export** (current Whoop dashboard export): flat directory with
+  ``sleeps.csv``, ``workouts.csv``, ``physiological_cycles.csv``, and
+  ``journal_entries.csv``. Daily-aggregate data. No granular per-minute HR.
+- **GDPR full export** (legacy, from https://privacy.whoop.com/): ``Health/``
+  subdirectory with ``sleeps.csv`` (different schema, with ``during`` JSON
+  tuple), ``metrics*.csv`` granular per-minute HR/accel/skin temp.
+
+Format is auto-detected from directory contents.
 """
 
 from datetime import timedelta
 from pathlib import Path
+from typing import Literal
 
 import pandas as pd
 
 from ..config import load_config
 
+WhoopFormat = Literal["standard", "gdpr"]
 
-def load_heartrate_df() -> pd.DataFrame:
-    whoop_export_dir = load_config()["data"]["whoop"]
+
+def _whoop_dir() -> Path:
+    return Path(load_config()["data"]["whoop"]).expanduser()
+
+
+def _detect_format(d: Path) -> WhoopFormat:
+    """Return 'standard' for new CSV export, 'gdpr' for legacy full-export.
+
+    Detection: ``physiological_cycles.csv`` only exists in the standard export;
+    a ``Health/`` subdirectory is the GDPR-format signature.
+    """
+    if (d / "physiological_cycles.csv").exists():
+        return "standard"
+    if (d / "Health").is_dir():
+        return "gdpr"
+    raise FileNotFoundError(
+        f"Whoop export not recognized at {d}. "
+        f"Expected either 'physiological_cycles.csv' (standard) "
+        f"or 'Health/' subdir (GDPR)."
+    )
+
+
+# ── Standard CSV export (current Whoop dashboard export) ──────────────────────
+
+
+def _parse_local_dt(s: pd.Series, tz_col: pd.Series) -> pd.Series:
+    """Parse naive local datetimes with per-row timezone offset → UTC.
+
+    Whoop CSVs ship naive local timestamps alongside a ``Cycle timezone``
+    column like ``UTC+02:00`` or ``UTC-05:00``. Combine to get a true UTC
+    instant.
+    """
+    naive = pd.to_datetime(s, errors="coerce")
+    # Whoop tz format: "UTC+02:00". Parse to hours offset.
+    offsets_hours = (
+        tz_col.str.replace("UTC", "", regex=False)
+        .str.replace(":", ".", regex=False)
+        .astype(float)
+    )
+    # Convert decimal hours like 2.30 → 2.5 (only matters for half-hour zones)
+    offsets_hours = offsets_hours.apply(
+        lambda x: int(x) + (x - int(x)) * (10 / 6) if pd.notna(x) else x
+    )
+    return naive - pd.to_timedelta(offsets_hours, unit="h")
+
+
+def _load_sleep_standard(d: Path) -> pd.DataFrame:
+    """Load daily sleep summary from new-format ``sleeps.csv``.
+
+    Index: date (waking day, derived from ``Wake onset`` local date).
+    Excludes naps from the main per-day record.
+    """
+    path = d / "sleeps.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"Whoop sleeps.csv not found at {path}")
+
+    # sleeps.csv columns (standard CSV export, as of 2026-05): "Cycle start time",
+    # "Cycle end time", "Cycle timezone", "Sleep onset", "Wake onset",
+    # "Sleep performance %", "Respiratory rate (rpm)", "Asleep duration (min)",
+    # "In bed duration (min)", "Light sleep duration (min)",
+    # "Deep (SWS) duration (min)", "REM duration (min)", "Awake duration (min)",
+    # "Sleep need (min)", "Sleep debt (min)", "Sleep efficiency %",
+    # "Sleep consistency %", "Nap"
+    df = pd.read_csv(path)
+    df = df[df["Nap"].astype(str).str.lower() != "true"].copy()
+
+    # Wake onset is naive local time; use its local date as the index.
+    wake_local = pd.to_datetime(df["Wake onset"], errors="coerce")
+    df = df[wake_local.notna()].copy()
+    wake_local = wake_local[wake_local.notna()]
+
+    out = pd.DataFrame(
+        {
+            "score": df["Sleep performance %"],
+            "duration": pd.to_timedelta(df["Asleep duration (min)"], unit="m"),
+            "time_in_bed": pd.to_timedelta(df["In bed duration (min)"], unit="m"),
+            "efficiency": df["Sleep efficiency %"],
+            "consistency": df["Sleep consistency %"],
+            "debt": df["Sleep debt (min)"],
+            "respiratory_rate": df["Respiratory rate (rpm)"],
+            "rem": pd.to_timedelta(df["REM duration (min)"], unit="m"),
+            "deep": pd.to_timedelta(df["Deep (SWS) duration (min)"], unit="m"),
+            "light": pd.to_timedelta(df["Light sleep duration (min)"], unit="m"),
+            "awake": pd.to_timedelta(df["Awake duration (min)"], unit="m"),
+        }
+    )
+    out.index = pd.to_datetime(wake_local.dt.date, utc=True)
+    out.index.name = "timestamp"
+    return out.sort_index()
+
+
+def _load_cycles_standard(d: Path) -> pd.DataFrame:
+    """Load daily cycle metrics from ``physiological_cycles.csv``.
+
+    This is the daily HR / HRV / recovery / strain row — replaces the
+    granular ``metrics*.csv`` loader from the GDPR export at daily resolution.
+    """
+    path = d / "physiological_cycles.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"Whoop physiological_cycles.csv not found at {path}")
+
+    # physiological_cycles.csv columns (standard CSV export, as of 2026-05):
+    # "Cycle start time", "Cycle end time", "Cycle timezone", "Recovery score %",
+    # "Resting heart rate (bpm)", "Heart rate variability (ms)",
+    # "Skin temp (celsius)", "Blood oxygen %", "Day Strain", "Energy burned (cal)",
+    # "Max HR (bpm)", "Average HR (bpm)", "Sleep onset", "Wake onset",
+    # "Sleep performance %", "Respiratory rate (rpm)", "Asleep duration (min)",
+    # "In bed duration (min)", "Light sleep duration (min)",
+    # "Deep (SWS) duration (min)", "REM duration (min)", "Awake duration (min)",
+    # "Sleep need (min)", "Sleep debt (min)", "Sleep efficiency %",
+    # "Sleep consistency %"
+    df = pd.read_csv(path)
+
+    # Use Wake onset for date assignment (same convention as sleep)
+    wake_local = pd.to_datetime(df["Wake onset"], errors="coerce")
+    df = df[wake_local.notna()].copy()
+    wake_local = wake_local[wake_local.notna()]
+
+    out = pd.DataFrame(
+        {
+            "recovery": df["Recovery score %"],
+            "resting_hr": df["Resting heart rate (bpm)"],
+            "hrv": df["Heart rate variability (ms)"],
+            "skin_temp": df["Skin temp (celsius)"],
+            "spo2": df["Blood oxygen %"],
+            "strain": df["Day Strain"],
+            "energy_kcal": df["Energy burned (cal)"],
+        }
+    )
+    out.index = pd.to_datetime(wake_local.dt.date, utc=True)
+    out.index.name = "timestamp"
+    return out.sort_index()
+
+
+def _load_workouts_standard(d: Path) -> pd.DataFrame:
+    """Load workout events from ``workouts.csv`` (event-level, one row per workout)."""
+    path = d / "workouts.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"Whoop workouts.csv not found at {path}")
+
+    # workouts.csv columns (standard CSV export, as of 2026-05):
+    # "Cycle start time", "Cycle end time", "Cycle timezone",
+    # "Workout start time", "Workout end time", "Duration (min)",
+    # "Activity name", "Activity Strain", "Energy burned (cal)",
+    # "Max HR (bpm)", "Average HR (bpm)",
+    # "HR Zone 1 %", "HR Zone 2 %", "HR Zone 3 %", "HR Zone 4 %", "HR Zone 5 %",
+    # "GPS enabled"
+    df = pd.read_csv(path)
+    df["start"] = pd.to_datetime(df["Workout start time"], errors="coerce", utc=True)
+    df["end"] = pd.to_datetime(df["Workout end time"], errors="coerce", utc=True)
+    df["duration"] = pd.to_timedelta(df["Duration (min)"], unit="m")
+    return df.rename(
+        columns={
+            "Activity name": "activity",
+            "Activity Strain": "strain",
+            "Energy burned (cal)": "energy_kcal",
+            "Max HR (bpm)": "max_hr",
+            "Average HR (bpm)": "avg_hr",
+        }
+    )[
+        [
+            "start",
+            "end",
+            "duration",
+            "activity",
+            "strain",
+            "energy_kcal",
+            "max_hr",
+            "avg_hr",
+        ]
+    ]
+
+
+def _load_journal_standard(d: Path) -> pd.DataFrame:
+    """Load journal entries from ``journal_entries.csv``.
+
+    Event-level: one row per question-answer. Includes free-text Notes column
+    when present — callers wanting privacy-aware aggregation should pivot via
+    :func:`load_journal_daily_df` instead.
+    """
+    path = d / "journal_entries.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"Whoop journal_entries.csv not found at {path}")
+
+    # journal_entries.csv columns (standard CSV export, as of 2026-05):
+    # "Cycle start time", "Cycle end time", "Cycle timezone",
+    # "Question text", "Answered yes" (bool string), "Notes" (free text, often empty)
+    # Question text is full natural-language ("Engaged in sexual activity?",
+    # "Have any caffeine?", etc.) — Whoop changes the set of questions over time.
+    df = pd.read_csv(path)
+    df["cycle_start"] = pd.to_datetime(df["Cycle start time"], errors="coerce", utc=True)
+    df = df.rename(
+        columns={
+            "Question text": "question",
+            "Answered yes": "answered_yes",
+            "Notes": "notes",
+        }
+    )
+    return df[["cycle_start", "question", "answered_yes", "notes"]]
+
+
+def load_journal_daily_df(include_notes: bool = False) -> pd.DataFrame:
+    """Pivot journal entries to one row per day, one column per question.
+
+    Returns a DataFrame with date index and one boolean column per Whoop
+    journal question (e.g. ``slept_well``, ``stressed``). Question text is
+    normalized to a snake_case key.
+
+    Parameters
+    ----------
+    include_notes
+        If True, also include a 'journal_notes' column with concatenated
+        free-text notes for the day. Default False for privacy (notes can
+        contain sensitive personal context).
+    """
+    raw = _load_journal_standard(_whoop_dir())
+    raw["date"] = raw["cycle_start"].dt.date
+    raw["question_key"] = raw["question"].apply(_question_to_key)
+
+    pivot = raw.pivot_table(
+        index="date",
+        columns="question_key",
+        values="answered_yes",
+        aggfunc=lambda s: any(str(v).lower() == "true" for v in s),
+    )
+    pivot.index = pd.to_datetime(pivot.index, utc=True)
+    pivot.index.name = "timestamp"
+
+    if include_notes:
+        notes_per_day = (
+            raw.dropna(subset=["notes"])
+            .groupby("date")["notes"]
+            .apply(lambda s: " | ".join(str(n) for n in s if str(n).strip()))
+        )
+        pivot["notes"] = notes_per_day
+        pivot["notes"] = pivot["notes"].reindex(pivot.index.date)
+
+    return pivot.sort_index()
+
+
+def _question_to_key(question: str) -> str:
+    """Normalize a Whoop journal question to a stable snake_case column key.
+
+    Examples
+    --------
+    >>> _question_to_key("Engaged in sexual activity?")
+    'engaged_in_sexual_activity'
+    >>> _question_to_key("Have any caffeine?")
+    'caffeine'
+    >>> _question_to_key("Felt stressed today?")
+    'stressed'
+    """
+    import re
+
+    if not isinstance(question, str):
+        return "unknown"
+    # Strip leading verbs/auxiliaries to get to the noun phrase
+    q = question.lower().strip().rstrip("?").strip()
+    for prefix in (
+        "have any ",
+        "had any ",
+        "any ",
+        "felt ",
+        "feel ",
+        "did you ",
+        "do you ",
+        "are you ",
+    ):
+        if q.startswith(prefix):
+            q = q[len(prefix) :]
+            break
+    # Remove trailing "today" / "yesterday"
+    q = re.sub(r"\s+(today|yesterday)$", "", q)
+    # Normalize to snake_case
+    q = re.sub(r"[^a-z0-9]+", "_", q).strip("_")
+    return q or "unknown"
+
+
+# ── GDPR full export (legacy) ─────────────────────────────────────────────────
+
+
+def _load_heartrate_gdpr(d: Path) -> pd.DataFrame:
+    """Granular per-minute HR from the GDPR-export ``Health/metrics*.csv`` files."""
+    health = d / "Health"
+    if not health.is_dir():
+        raise FileNotFoundError(f"Whoop GDPR Health/ dir not found at {health}")
+
+    # Health/metrics-*.csv columns (GDPR full export): hr, accel_x, accel_y,
+    # accel_z, skin_temp, ts — one row per minute. Multiple files split by
+    # date range; concatenated here.
     dfs = []
-    for file in (Path(whoop_export_dir) / "Health").expanduser().iterdir():
+    for file in health.iterdir():
         if file.name.startswith("metrics") and file.name.endswith(".csv"):
-            df = pd.read_csv(Path(file).expanduser(), parse_dates=True)
+            df = pd.read_csv(file, parse_dates=True)
             dfs.append(df)
+    if not dfs:
+        raise FileNotFoundError(f"No metrics*.csv files in {health}")
 
-    # df columns are: hr, accel_x, accel_y, accel_z, skin_temp, ts
-    # combine dfs together
     df = pd.concat(dfs, ignore_index=True)
     df = df.set_index(pd.DatetimeIndex(df["ts"]))
     del df["ts"]
-
-    # drop non-HR columns
-    df = df[["hr"]]
-
-    # sort
-    df = df.sort_index()
-
-    # rename index to timestamp
+    # Only HR kept here; accel_*/skin_temp available in raw df if needed
+    df = df[["hr"]].sort_index()
     df.index.name = "timestamp"
-
     return df
 
 
-def load_sleep_df() -> pd.DataFrame:
-    whoop_export_dir = load_config()["data"]["whoop"]
-    filename = Path(whoop_export_dir) / "Health" / "sleeps.csv"
-    df = pd.read_csv(filename.expanduser(), parse_dates=True)
+def _load_sleep_gdpr(d: Path) -> pd.DataFrame:
+    """Legacy GDPR-format sleep load (uses ``during`` JSON-tuple column)."""
+    path = d / "Health" / "sleeps.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"Whoop GDPR sleeps.csv not found at {path}")
 
-    # df columns are: "created_at","updated_at","activity_id","score","quality_duration","latency","max_heart_rate","average_heart_rate","debt_pre","debt_post","need_from_strain","sleep_need","habitual_sleep_need","disturbances","time_in_bed","light_sleep_duration","slow_wave_sleep_duration","rem_sleep_duration","cycles_count","wake_duration","arousal_time","no_data_duration","in_sleep_efficiency","credit_from_naps","hr_baseline","respiratory_rate","sleep_consistency","algo_version","projected_score","projected_sleep","optimal_sleep_times","kilojoules","user_id","during","timezone_offset","survey_response_id","percent_recorded","auto_detected","state","responded","team_act_id","source","is_significant","is_normal","is_nap"
-    # we are interested in the "during" column, which is a JSON string of a 2-tuple with isoformat timestamps
+    # Health/sleeps.csv columns (GDPR full export): created_at, updated_at,
+    # activity_id, score, quality_duration, latency, max_heart_rate,
+    # average_heart_rate, debt_pre, debt_post, need_from_strain, sleep_need,
+    # habitual_sleep_need, disturbances, time_in_bed, light_sleep_duration,
+    # slow_wave_sleep_duration, rem_sleep_duration, cycles_count,
+    # wake_duration, arousal_time, no_data_duration, in_sleep_efficiency,
+    # credit_from_naps, hr_baseline, respiratory_rate, sleep_consistency,
+    # algo_version, projected_score, projected_sleep, optimal_sleep_times,
+    # kilojoules, user_id, during, timezone_offset, survey_response_id,
+    # percent_recorded, auto_detected, state, responded, team_act_id, source,
+    # is_significant, is_normal, is_nap
+    # The "during" column is a Postgres tstzrange string with start/end
+    # iso-format timestamps; we extract those as start/end columns.
+    df = pd.read_csv(path, parse_dates=True)
+
     def parse_during(x):
-        try:
-            return eval(x.replace(")", "]"))
-        except:
-            print(x)
-            raise
+        return eval(x.replace(")", "]"))
 
     df["start"] = pd.to_datetime(df["during"].apply(lambda x: parse_during(x)[0]))
     df["end"] = pd.to_datetime(df["during"].apply(lambda x: parse_during(x)[1]))
     df["duration"] = df["end"] - df["start"]
 
-    # keep only the columns we want
     df = df[["start", "end", "duration", "score"]]
 
-    # set index and sort
+    # Hard-coded 8-hour offset retained from legacy code — works for Erik's
+    # historical data (UTC+8 era). Re-evaluate if older data with different
+    # timezones is loaded.
     offset = timedelta(hours=8)
     df = df.set_index(
         pd.to_datetime(pd.DatetimeIndex(df["start"] - offset).date, utc=True)  # type: ignore[arg-type]
     )
     df = df.sort_index()
-
-    # rename index to timestamp
     df.index.name = "timestamp"
-
     return df
+
+
+# ── Public API (format-dispatching) ───────────────────────────────────────────
+
+
+def load_heartrate_df() -> pd.DataFrame:
+    """Load granular HR data. Only available for GDPR-format exports.
+
+    Standard exports don't include per-minute HR — use :func:`load_cycles_df`
+    for daily HR/HRV summaries instead.
+    """
+    d = _whoop_dir()
+    fmt = _detect_format(d)
+    if fmt == "gdpr":
+        return _load_heartrate_gdpr(d)
+    raise NotImplementedError(
+        f"Granular heartrate data not available in '{fmt}' Whoop export format. "
+        f"Use load_cycles_df() for daily HR/HRV summary, or request a GDPR "
+        f"full export from https://privacy.whoop.com/."
+    )
+
+
+def load_sleep_df() -> pd.DataFrame:
+    """Load daily sleep summary. Works for both export formats."""
+    d = _whoop_dir()
+    fmt = _detect_format(d)
+    if fmt == "standard":
+        return _load_sleep_standard(d)
+    return _load_sleep_gdpr(d)
+
+
+def load_cycles_df() -> pd.DataFrame:
+    """Load daily physiological cycle summary (recovery, HRV, RHR, strain).
+
+    Only available in the standard export format.
+    """
+    d = _whoop_dir()
+    if _detect_format(d) != "standard":
+        raise NotImplementedError(
+            "Cycle data only available in standard Whoop export, not GDPR full export."
+        )
+    return _load_cycles_standard(d)
+
+
+def load_workouts_df() -> pd.DataFrame:
+    """Load workout events. Only available in the standard export format."""
+    d = _whoop_dir()
+    if _detect_format(d) != "standard":
+        raise NotImplementedError(
+            "Workout data only available in standard Whoop export, not GDPR full export."
+        )
+    return _load_workouts_standard(d)

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -207,6 +207,8 @@ def _load_journal_standard(d: Path) -> pd.DataFrame:
     # "Have any caffeine?", etc.) — Whoop changes the set of questions over time.
     df = pd.read_csv(path)
     df["cycle_start"] = pd.to_datetime(df["Cycle start time"], errors="coerce", utc=True)
+    if "Notes" not in df.columns:
+        df["Notes"] = pd.NA
     df = df.rename(
         columns={
             "Question text": "question",

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -206,7 +206,9 @@ def _load_journal_standard(d: Path) -> pd.DataFrame:
     # Question text is full natural-language ("Engaged in sexual activity?",
     # "Have any caffeine?", etc.) — Whoop changes the set of questions over time.
     df = pd.read_csv(path)
-    df["cycle_start"] = pd.to_datetime(df["Cycle start time"], errors="coerce", utc=True)
+    df["cycle_start"] = pd.to_datetime(
+        df["Cycle start time"], errors="coerce", utc=True
+    )
     if "Notes" not in df.columns:
         df["Notes"] = pd.NA
     df = df.rename(

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -48,25 +48,17 @@ def _detect_format(d: Path) -> WhoopFormat:
 # ── Standard CSV export (current Whoop dashboard export) ──────────────────────
 
 
-def _parse_local_dt(s: pd.Series, tz_col: pd.Series) -> pd.Series:
-    """Parse naive local datetimes with per-row timezone offset → UTC.
+def _to_utc(timestamp_col: pd.Series, tz_col: pd.Series) -> pd.Series:
+    """Convert naive local timestamps + per-row tz offset → UTC.
 
-    Whoop CSVs ship naive local timestamps alongside a ``Cycle timezone``
-    column like ``UTC+02:00`` or ``UTC-05:00``. Combine to get a true UTC
-    instant.
+    Whoop CSVs ship the local timestamp in one column and the offset in
+    another (e.g. ``"2026-05-09 16:52:30"`` + ``"UTC+02:00"``). Concatenate
+    into an ISO-with-offset string and let pandas convert to UTC.
     """
-    naive = pd.to_datetime(s, errors="coerce")
-    # Whoop tz format: "UTC+02:00". Parse to hours offset.
-    offsets_hours = (
-        tz_col.str.replace("UTC", "", regex=False)
-        .str.replace(":", ".", regex=False)
-        .astype(float)
-    )
-    # Convert decimal hours like 2.30 → 2.5 (only matters for half-hour zones)
-    offsets_hours = offsets_hours.apply(
-        lambda x: int(x) + (x - int(x)) * (10 / 6) if pd.notna(x) else x
-    )
-    return naive - pd.to_timedelta(offsets_hours, unit="h")
+    # "UTC+02:00" → "+02:00"; pandas understands ISO with offset directly.
+    offset = tz_col.str.replace("UTC", "", regex=False)
+    iso = timestamp_col.astype(str) + offset.astype(str)
+    return pd.to_datetime(iso, utc=True, errors="coerce")
 
 
 def _load_sleep_standard(d: Path) -> pd.DataFrame:
@@ -171,8 +163,9 @@ def _load_workouts_standard(d: Path) -> pd.DataFrame:
     # "HR Zone 1 %", "HR Zone 2 %", "HR Zone 3 %", "HR Zone 4 %", "HR Zone 5 %",
     # "GPS enabled"
     df = pd.read_csv(path)
-    df["start"] = pd.to_datetime(df["Workout start time"], errors="coerce", utc=True)
-    df["end"] = pd.to_datetime(df["Workout end time"], errors="coerce", utc=True)
+    # Workout timestamps are naive local; convert using each row's "Cycle timezone".
+    df["start"] = _to_utc(df["Workout start time"], df["Cycle timezone"])
+    df["end"] = _to_utc(df["Workout end time"], df["Cycle timezone"])
     df["duration"] = pd.to_timedelta(df["Duration (min)"], unit="m")
     return df.rename(
         columns={
@@ -257,8 +250,11 @@ def load_journal_daily_df(include_notes: bool = False) -> pd.DataFrame:
             .groupby("date")["notes"]
             .apply(lambda s: " | ".join(str(n) for n in s if str(n).strip()))
         )
+        # notes_per_day is indexed by Python date; pivot.index is a UTC
+        # DatetimeIndex. Bring them into the same shape before assignment,
+        # otherwise pandas aligns by value and silently fills all NaN.
+        notes_per_day.index = pd.to_datetime(notes_per_day.index, utc=True)
         pivot["notes"] = notes_per_day
-        pivot["notes"] = pivot["notes"].reindex(pivot.index.date)
 
     return pivot.sort_index()
 
@@ -349,10 +345,18 @@ def _load_sleep_gdpr(d: Path) -> pd.DataFrame:
     # is_significant, is_normal, is_nap
     # The "during" column is a Postgres tstzrange string with start/end
     # iso-format timestamps; we extract those as start/end columns.
+    import ast
+
     df = pd.read_csv(path, parse_dates=True)
 
     def parse_during(x):
-        return eval(x.replace(")", "]"))
+        # tstzrange ships as e.g. `["2022-01-01T00:00:00","2022-01-01T08:00:00")`.
+        # Rewrite the closing paren to make it a Python-syntax list, then
+        # literal_eval (safer than eval on file content).
+        try:
+            return ast.literal_eval(x.replace(")", "]"))
+        except (ValueError, SyntaxError):
+            raise ValueError(f"Could not parse `during` value: {x!r}") from None
 
     df["start"] = pd.to_datetime(df["during"].apply(lambda x: parse_during(x)[0]))
     df["end"] = pd.to_datetime(df["during"].apply(lambda x: parse_during(x)[1]))

--- a/src/quantifiedme/load/whoop.py
+++ b/src/quantifiedme/load/whoop.py
@@ -206,9 +206,10 @@ def _load_journal_standard(d: Path) -> pd.DataFrame:
     # Question text is full natural-language ("Engaged in sexual activity?",
     # "Have any caffeine?", etc.) — Whoop changes the set of questions over time.
     df = pd.read_csv(path)
-    df["cycle_start"] = pd.to_datetime(
-        df["Cycle start time"], errors="coerce", utc=True
-    )
+    # Use Cycle end time (= wake morning) to match the wake-date convention
+    # used by _load_sleep_standard / _load_cycles_standard. Using Cycle start
+    # time would offset journal rows one day behind sleep/cycles in joins.
+    df["cycle_end"] = pd.to_datetime(df["Cycle end time"], errors="coerce", utc=True)
     if "Notes" not in df.columns:
         df["Notes"] = pd.NA
     df = df.rename(
@@ -218,7 +219,7 @@ def _load_journal_standard(d: Path) -> pd.DataFrame:
             "Notes": "notes",
         }
     )
-    return df[["cycle_start", "question", "answered_yes", "notes"]]
+    return df[["cycle_end", "question", "answered_yes", "notes"]]
 
 
 def load_journal_daily_df(include_notes: bool = False) -> pd.DataFrame:
@@ -236,7 +237,7 @@ def load_journal_daily_df(include_notes: bool = False) -> pd.DataFrame:
         contain sensitive personal context).
     """
     raw = _load_journal_standard(_whoop_dir())
-    raw["date"] = raw["cycle_start"].dt.date
+    raw["date"] = raw["cycle_end"].dt.date
     raw["question_key"] = raw["question"].apply(_question_to_key)
 
     pivot = raw.pivot_table(

--- a/tests/test_load_whoop.py
+++ b/tests/test_load_whoop.py
@@ -1,17 +1,328 @@
+"""Tests for the Whoop data loader.
+
+Covers both the standard CSV export format (current Whoop dashboard) and the
+GDPR full-export format (legacy). Standard-format paths are tested with fixture
+CSVs that match the actual column schemas Whoop ships (verified against Erik's
+2026-05-13 export).
+"""
+
+from pathlib import Path
+
+import pandas as pd
 import pytest
+
 from quantifiedme.config import load_config
-from quantifiedme.load.whoop import load_heartrate_df, load_sleep_df
+from quantifiedme.load import whoop
+from quantifiedme.load.whoop import (
+    _detect_format,
+    _load_cycles_standard,
+    _load_journal_standard,
+    _load_sleep_standard,
+    _load_workouts_standard,
+    _question_to_key,
+    load_cycles_df,
+    load_heartrate_df,
+    load_journal_daily_df,
+    load_sleep_df,
+    load_workouts_df,
+)
 
 has_whoop_config = load_config().get("data", {}).get("whoop", False)
 
 
-@pytest.mark.skipif(not has_whoop_config, reason="no whoop config")
-def test_load_whoop_heartrate():
-    df = load_heartrate_df()
-    print(df.head())
+# ── Fixture CSV content (matches Whoop standard export schemas, 2026-05) ──────
 
 
-@pytest.mark.skipif(not has_whoop_config, reason="no whoop config")
-def test_load_whoop_sleep():
+SLEEPS_CSV = """\
+Cycle start time,Cycle end time,Cycle timezone,Sleep onset,Wake onset,Sleep performance %,Respiratory rate (rpm),Asleep duration (min),In bed duration (min),Light sleep duration (min),Deep (SWS) duration (min),REM duration (min),Awake duration (min),Sleep need (min),Sleep debt (min),Sleep efficiency %,Sleep consistency %,Nap
+2026-05-09 23:00:00,2026-05-10 07:00:00,UTC+02:00,2026-05-09 23:15:00,2026-05-10 07:00:00,92,15.2,450,475,210,110,130,25,480,30,94,85,false
+2026-05-10 23:30:00,2026-05-11 06:45:00,UTC+02:00,2026-05-10 23:45:00,2026-05-11 06:45:00,88,15.5,415,435,200,100,115,20,480,65,95,80,false
+2026-05-11 13:00:00,2026-05-11 13:45:00,UTC+02:00,2026-05-11 13:05:00,2026-05-11 13:40:00,50,15.0,35,40,20,5,10,5,0,0,87,0,true
+"""
+
+CYCLES_CSV = """\
+Cycle start time,Cycle end time,Cycle timezone,Recovery score %,Resting heart rate (bpm),Heart rate variability (ms),Skin temp (celsius),Blood oxygen %,Day Strain,Energy burned (cal),Max HR (bpm),Average HR (bpm),Sleep onset,Wake onset,Sleep performance %,Respiratory rate (rpm),Asleep duration (min),In bed duration (min),Light sleep duration (min),Deep (SWS) duration (min),REM duration (min),Awake duration (min),Sleep need (min),Sleep debt (min),Sleep efficiency %,Sleep consistency %
+2026-05-09 23:00:00,2026-05-10 23:00:00,UTC+02:00,72,52,58,33.1,96,12.5,2600,165,75,2026-05-09 23:15:00,2026-05-10 07:00:00,92,15.2,450,475,210,110,130,25,480,30,94,85
+2026-05-10 23:30:00,2026-05-11 23:30:00,UTC+02:00,65,55,52,33.4,95,14.2,2800,172,78,2026-05-10 23:45:00,2026-05-11 06:45:00,88,15.5,415,435,200,100,115,20,480,65,95,80
+"""
+
+WORKOUTS_CSV = """\
+Cycle start time,Cycle end time,Cycle timezone,Workout start time,Workout end time,Duration (min),Activity name,Activity Strain,Energy burned (cal),Max HR (bpm),Average HR (bpm),HR Zone 1 %,HR Zone 2 %,HR Zone 3 %,HR Zone 4 %,HR Zone 5 %,GPS enabled
+2026-05-10 23:00:00,2026-05-11 23:00:00,UTC+02:00,2026-05-10 18:00:00,2026-05-10 19:00:00,60,Running,9.5,520,175,142,5,15,45,30,5,true
+"""
+
+JOURNAL_CSV = """\
+Cycle start time,Cycle end time,Cycle timezone,Question text,Answered yes,Notes
+2026-05-09 23:00:00,2026-05-10 23:00:00,UTC+02:00,Have any caffeine?,true,
+2026-05-09 23:00:00,2026-05-10 23:00:00,UTC+02:00,Felt stressed today?,false,
+2026-05-09 23:00:00,2026-05-10 23:00:00,UTC+02:00,Engaged in sexual activity?,true,a private note
+2026-05-10 23:30:00,2026-05-11 23:30:00,UTC+02:00,Have any caffeine?,false,
+2026-05-10 23:30:00,2026-05-11 23:30:00,UTC+02:00,Felt stressed today?,true,big deadline
+"""
+
+
+@pytest.fixture
+def standard_export(tmp_path: Path) -> Path:
+    """Create a complete standard-format Whoop export directory."""
+    (tmp_path / "sleeps.csv").write_text(SLEEPS_CSV)
+    (tmp_path / "physiological_cycles.csv").write_text(CYCLES_CSV)
+    (tmp_path / "workouts.csv").write_text(WORKOUTS_CSV)
+    (tmp_path / "journal_entries.csv").write_text(JOURNAL_CSV)
+    return tmp_path
+
+
+@pytest.fixture
+def gdpr_export(tmp_path: Path) -> Path:
+    """Create a minimal GDPR-format Whoop export (Health/ subdir only)."""
+    (tmp_path / "Health").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def patched_whoop_dir(monkeypatch: pytest.MonkeyPatch, standard_export: Path) -> Path:
+    """Point the public API at a fixture directory by patching _whoop_dir."""
+    monkeypatch.setattr(whoop, "_whoop_dir", lambda: standard_export)
+    return standard_export
+
+
+# ── Format detection ──────────────────────────────────────────────────────────
+
+
+def test_detect_format_standard(standard_export: Path) -> None:
+    assert _detect_format(standard_export) == "standard"
+
+
+def test_detect_format_gdpr(gdpr_export: Path) -> None:
+    assert _detect_format(gdpr_export) == "gdpr"
+
+
+def test_detect_format_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Whoop export not recognized"):
+        _detect_format(tmp_path)
+
+
+# ── Standard-format loaders ───────────────────────────────────────────────────
+
+
+def test_load_sleep_standard(standard_export: Path) -> None:
+    df = _load_sleep_standard(standard_export)
+
+    # Nap row excluded → 2 rows
+    assert len(df) == 2
+    assert df.index.name == "timestamp"
+    assert str(df.index.tz) == "UTC"
+    assert df.index.is_monotonic_increasing
+
+    # Column presence
+    for col in (
+        "score",
+        "duration",
+        "time_in_bed",
+        "efficiency",
+        "consistency",
+        "debt",
+        "respiratory_rate",
+        "rem",
+        "deep",
+        "light",
+        "awake",
+    ):
+        assert col in df.columns, f"missing column: {col}"
+
+    # First row sanity (2026-05-10, score=92, 450 min asleep)
+    assert df.iloc[0]["score"] == 92
+    assert df.iloc[0]["duration"] == pd.Timedelta(minutes=450)
+
+
+def test_load_cycles_standard(standard_export: Path) -> None:
+    df = _load_cycles_standard(standard_export)
+
+    assert len(df) == 2
+    assert df.index.name == "timestamp"
+    assert str(df.index.tz) == "UTC"
+
+    for col in (
+        "recovery",
+        "resting_hr",
+        "hrv",
+        "skin_temp",
+        "spo2",
+        "strain",
+        "energy_kcal",
+    ):
+        assert col in df.columns
+
+    assert df.iloc[0]["recovery"] == 72
+    assert df.iloc[0]["resting_hr"] == 52
+    assert df.iloc[0]["hrv"] == 58
+
+
+def test_load_workouts_standard(standard_export: Path) -> None:
+    df = _load_workouts_standard(standard_export)
+
+    assert len(df) == 1
+    assert list(df.columns) == [
+        "start",
+        "end",
+        "duration",
+        "activity",
+        "strain",
+        "energy_kcal",
+        "max_hr",
+        "avg_hr",
+    ]
+    # Timezone conversion: 2026-05-10 18:00 UTC+02:00 → 16:00 UTC
+    assert df.iloc[0]["start"] == pd.Timestamp("2026-05-10 16:00:00", tz="UTC")
+    assert df.iloc[0]["end"] == pd.Timestamp("2026-05-10 17:00:00", tz="UTC")
+    assert df.iloc[0]["duration"] == pd.Timedelta(minutes=60)
+    assert df.iloc[0]["activity"] == "Running"
+
+
+def test_load_journal_standard_raw(standard_export: Path) -> None:
+    df = _load_journal_standard(standard_export)
+
+    assert len(df) == 5
+    assert list(df.columns) == ["cycle_start", "question", "answered_yes", "notes"]
+    assert str(df["cycle_start"].dt.tz) == "UTC"
+
+
+def test_load_journal_daily_df_pivot(patched_whoop_dir: Path) -> None:
+    df = load_journal_daily_df()
+
+    # Two days of pivoted data
+    assert len(df) == 2
+    assert df.index.name == "timestamp"
+    assert str(df.index.tz) == "UTC"
+
+    # Normalized column keys present
+    assert "caffeine" in df.columns
+    assert "stressed" in df.columns
+    assert "engaged_in_sexual_activity" in df.columns
+
+    # Day 1: caffeine=True, stressed=False, sex=True
+    assert df.iloc[0]["caffeine"] is True or df.iloc[0]["caffeine"] == True  # noqa: E712
+    assert df.iloc[0]["stressed"] is False or df.iloc[0]["stressed"] == False  # noqa: E712
+    # Day 2: caffeine=False, stressed=True
+    assert df.iloc[1]["caffeine"] is False or df.iloc[1]["caffeine"] == False  # noqa: E712
+    assert df.iloc[1]["stressed"] is True or df.iloc[1]["stressed"] == True  # noqa: E712
+
+    # Privacy default: notes excluded
+    assert "notes" not in df.columns
+
+
+def test_load_journal_daily_df_include_notes(patched_whoop_dir: Path) -> None:
+    df = load_journal_daily_df(include_notes=True)
+
+    assert "notes" in df.columns
+    # Day 1 had one non-empty note
+    day1_notes = df.iloc[0]["notes"]
+    assert isinstance(day1_notes, str)
+    assert "private note" in day1_notes
+
+
+# ── Public API dispatch ───────────────────────────────────────────────────────
+
+
+def test_load_sleep_df_dispatches_to_standard(patched_whoop_dir: Path) -> None:
     df = load_sleep_df()
-    print(df.head())
+    # Standard format returns 'score' + 'duration' columns (not start/end)
+    assert "score" in df.columns
+    assert "duration" in df.columns
+    assert "start" not in df.columns
+
+
+def test_load_cycles_df_dispatches(patched_whoop_dir: Path) -> None:
+    df = load_cycles_df()
+    assert "recovery" in df.columns
+    assert "hrv" in df.columns
+
+
+def test_load_workouts_df_dispatches(patched_whoop_dir: Path) -> None:
+    df = load_workouts_df()
+    assert "activity" in df.columns
+
+
+def test_load_heartrate_raises_on_standard_format(patched_whoop_dir: Path) -> None:
+    with pytest.raises(NotImplementedError, match="GDPR full export"):
+        load_heartrate_df()
+
+
+def test_load_cycles_raises_on_gdpr_format(
+    monkeypatch: pytest.MonkeyPatch, gdpr_export: Path
+) -> None:
+    monkeypatch.setattr(whoop, "_whoop_dir", lambda: gdpr_export)
+    with pytest.raises(NotImplementedError, match="standard Whoop export"):
+        load_cycles_df()
+
+
+# ── File-missing error paths ──────────────────────────────────────────────────
+
+
+def test_load_sleep_standard_missing_file(tmp_path: Path) -> None:
+    (tmp_path / "physiological_cycles.csv").write_text(
+        ""
+    )  # makes detect see "standard"
+    with pytest.raises(FileNotFoundError, match="sleeps.csv"):
+        _load_sleep_standard(tmp_path)
+
+
+def test_load_cycles_standard_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="physiological_cycles.csv"):
+        _load_cycles_standard(tmp_path)
+
+
+def test_load_workouts_standard_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="workouts.csv"):
+        _load_workouts_standard(tmp_path)
+
+
+def test_load_journal_standard_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="journal_entries.csv"):
+        _load_journal_standard(tmp_path)
+
+
+# ── Question text normalization ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "question,expected",
+    [
+        ("Have any caffeine?", "caffeine"),
+        ("Had any alcohol?", "alcohol"),
+        ("Felt stressed today?", "stressed"),
+        ("Feel energized today?", "energized"),
+        ("Engaged in sexual activity?", "engaged_in_sexual_activity"),
+        ("Did you read?", "read"),
+        ("Are you sick?", "sick"),
+        ("Any caffeine?", "caffeine"),
+        ("Slept in own bed yesterday?", "slept_in_own_bed"),
+        ("", "unknown"),
+    ],
+)
+def test_question_to_key(question: str, expected: str) -> None:
+    assert _question_to_key(question) == expected
+
+
+def test_question_to_key_non_string() -> None:
+    assert _question_to_key(None) == "unknown"  # type: ignore[arg-type]
+    assert _question_to_key(float("nan")) == "unknown"  # type: ignore[arg-type]
+
+
+# ── Live config integration (skipped without real data) ───────────────────────
+
+
+@pytest.mark.skipif(not has_whoop_config, reason="no whoop config")
+def test_load_whoop_sleep() -> None:
+    df = load_sleep_df()
+    assert len(df) > 0
+
+
+@pytest.mark.skipif(not has_whoop_config, reason="no whoop config")
+def test_load_whoop_heartrate_or_cycles() -> None:
+    # Whichever format the live config points at, one of these should succeed
+    try:
+        load_heartrate_df()
+    except NotImplementedError:
+        # Standard format — try cycles instead
+        df = load_cycles_df()
+        assert len(df) > 0

--- a/tests/test_load_whoop.py
+++ b/tests/test_load_whoop.py
@@ -184,8 +184,26 @@ def test_load_journal_standard_raw(standard_export: Path) -> None:
     df = _load_journal_standard(standard_export)
 
     assert len(df) == 5
-    assert list(df.columns) == ["cycle_start", "question", "answered_yes", "notes"]
-    assert str(df["cycle_start"].dt.tz) == "UTC"
+    assert list(df.columns) == ["cycle_end", "question", "answered_yes", "notes"]
+    assert str(df["cycle_end"].dt.tz) == "UTC"
+
+
+def test_journal_date_index_aligns_with_sleep(patched_whoop_dir: Path) -> None:
+    """Journal entries must be indexed by the same wake-date convention as sleep
+    and cycles loaders — otherwise all_df.py joins drop every row.
+
+    Greptile P1 (2026-05-19): cycle_start indexes journal one day behind sleep.
+    """
+    sleep = load_sleep_df()
+    journal = load_journal_daily_df()
+
+    # Both journal rows should match a sleep row by date. (Sleep has 3 rows
+    # because of the nap; journal has 2 rows from the 2 distinct cycle ends.)
+    common = sleep.index.intersection(journal.index)
+    assert len(common) == len(journal), (
+        f"Journal dates {list(journal.index)} should align with sleep dates "
+        f"{list(sleep.index)} — got {len(common)} aligned of {len(journal)}"
+    )
 
 
 def test_load_journal_daily_df_pivot(patched_whoop_dir: Path) -> None:

--- a/tests/test_load_whoop.py
+++ b/tests/test_load_whoop.py
@@ -110,6 +110,7 @@ def test_load_sleep_standard(standard_export: Path) -> None:
     # Nap row excluded → 2 rows
     assert len(df) == 2
     assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
     assert df.index.is_monotonic_increasing
 
@@ -139,6 +140,7 @@ def test_load_cycles_standard(standard_export: Path) -> None:
 
     assert len(df) == 2
     assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
 
     for col in (
@@ -192,6 +194,7 @@ def test_load_journal_daily_df_pivot(patched_whoop_dir: Path) -> None:
     # Two days of pivoted data
     assert len(df) == 2
     assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
 
     # Normalized column keys present


### PR DESCRIPTION
## Summary

Whoop now ships two distinct export formats and the existing loader only handled one. This PR adds the new format with auto-detection, preserves the legacy path, and adds loaders for two new file types — most importantly `journal_entries.csv`, which is event-level self-report data (Whoop's daily wellbeing questions).

### Background: two formats

| Format | How to get it | What's in it |
|---|---|---|
| **Standard CSV** (this PR's main target) | Whoop dashboard → Export | 4 flat files: `sleeps.csv`, `physiological_cycles.csv`, `workouts.csv`, `journal_entries.csv`. Daily-summary granularity. |
| **GDPR full** (existing) | <https://privacy.whoop.com/> | `Health/` subdir with `metrics-*.csv` (per-minute HR/accel/skin temp) and the older `sleeps.csv` schema with `during` tstzrange |

The new format is daily-summary only — per-minute HR no longer ships in the dashboard export. The GDPR path is the only way to get granular HR; this loader keeps that path working for the legacy archives at `~/annex/Logs/Whoop/2023-1-29/` and for fresh GDPR requests.

## Changes

### `src/quantifiedme/load/whoop.py` (rewrite)

- **Auto-detection**: `_detect_format(d)` returns `\"standard\"` if `physiological_cycles.csv` exists, `\"gdpr\"` if `Health/` subdir is present, else `FileNotFoundError`.
- **Dispatching public API**: existing callers of `load_sleep_df` / `load_heartrate_df` keep working. `load_heartrate_df()` raises `NotImplementedError` on standard exports with a pointer to `load_cycles_df()` (daily HR/HRV) or the GDPR export path.
- **New loaders** (standard-format only): `load_cycles_df` (daily HRV/RHR/recovery/strain/skin temp/SpO2), `load_workouts_df` (per-workout events with HR zone breakdown), `load_journal_daily_df` (pivot of journal entries to one column per question; `include_notes=False` default).
- **`_question_to_key`**: normalizes Whoop's natural-language question text to stable snake_case keys; strips leading auxiliaries (\"have any\", \"felt\", \"did you\") and trailing \"today\"/\"yesterday\" so question rephrasing across Whoop versions doesn't churn the column names downstream.
- **Timezone handling**: parses naive local timestamps + per-row \`Cycle timezone\` offset → UTC dates for indexing. Old loader hard-coded a UTC+8 offset.
- **Column-schema reference comments**: every loader function carries the file's column list inline. Saves re-inspecting CSVs when extending.

### Not in this PR (follow-up)

- Tests with fixture CSVs (column schemas + sample rows pasted above used as fixture content)
- Wiring \`journal\` as a new \`Sources\` literal in \`derived/all_df.py\` (so \`journal:<question_key>\` columns appear in \`load_all_df()\` output)
- \`derived/heartrate.py\` update to fall back to \`load_cycles_df()\` when granular HR isn't available
- Lint/typecheck pass

Marking this **draft** so the loader can be reviewed in isolation before adding integration. Happy to roll the follow-ups into this PR or split — preference?

## Privacy note

\`load_journal_daily_df(include_notes=False)\` is the default. The Notes column can contain free-text personal context and is opt-in only.

## Test plan

- [ ] Add fixture-based tests for new-format loaders (sleeps, cycles, workouts, journal)
- [ ] Add format-detection tests (standard, gdpr, missing)
- [ ] Verify legacy GDPR loaders still work against existing \`~/annex/Logs/Whoop/2023-1-29/\` archive
- [ ] Run \`load_all_df(fast=False)\` end-to-end on erb-m2 with the 2026-05-13 export; verify \`sleep:*\` and (eventually) \`journal:*\` columns flow through
- [ ] Confirm \`qs-export.py\` consuming \`load_all_df()\` output passes the new columns through to the JSON/CSV sync

## Related

- Design context: agent-human QS unification work; \`journal_entries.csv\` is the strongest grounding source identified for the wellbeing dimension of the LLM-as-judge integration. Lives in Alice's repo: \`knowledge/quantified-self/agent-human-qs-unification.md\`.
- Follow-on tracked at: \`alice/tasks/qm-whoop-new-format-loader.md\`