### PR TITLE
feat(predict): Bayesian sleep/wellbeing model (whoop:recovery)

### DIFF
--- a/src/quantifiedme/predict/cli.py
+++ b/src/quantifiedme/predict/cli.py
@@ -89,7 +89,7 @@ def cmd_sleep(args: argparse.Namespace) -> None:
         n_samples=args.samples,
         n_tune=args.tune,
         max_features=args.max_features,
-        include_screentime=not args.no_screentime,
+        include_screentime=args.screentime,
     )
     _print_bayesian_result(result)
 
@@ -193,10 +193,10 @@ def main(argv: list[str] | None = None) -> None:
     p_sleep.add_argument("--tune", type=int, default=1000, help="Tuning steps")
     p_sleep.add_argument("--max-features", type=int, default=12, help="Max features to select")
     p_sleep.add_argument(
-        "--no-screentime",
+        "--screentime",
         action="store_true",
-        help="Drop AW screen-time features (extends valid history to pre-2022 "
-        "for sleep targets; physiology doesn't need screen-time anyway)",
+        help="Include AW screen-time features (limits training to post-2021 data; "
+        "default is to exclude them so physiology targets use the full history)",
     )
     p_sleep.set_defaults(func=cmd_sleep)
 

--- a/src/quantifiedme/predict/cli.py
+++ b/src/quantifiedme/predict/cli.py
@@ -7,6 +7,8 @@ Usage:
     python -m quantifiedme.predict features data.csv
     python -m quantifiedme.predict bayesian data.csv
     python -m quantifiedme.predict bayesian data.csv --target time:Programming --samples 2000
+    python -m quantifiedme.predict sleep data.csv
+    python -m quantifiedme.predict sleep data.csv --target sleep:score
     python -m quantifiedme.predict simulate data.csv --add caffeine
     python -m quantifiedme.predict simulate data.csv --remove alcohol --add nicotine
     python -m quantifiedme.predict simulate data.csv --add caffeine --target time:Programming
@@ -15,6 +17,10 @@ Usage:
 import argparse
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models.work import BayesianWorkResult
 
 
 def cmd_baseline(args: argparse.Namespace) -> None:
@@ -32,6 +38,29 @@ def cmd_diagnostic(args: argparse.Namespace) -> None:
     run_diagnostic(args.csv, targets=targets)
 
 
+def _print_bayesian_result(result: "BayesianWorkResult") -> None:
+    """Print model summary, recent predictions, and CI coverage."""
+    print(result.summary())
+    print()
+
+    # Show credible intervals for recent test predictions
+    ci = result.credible_intervals()
+    print("Recent test predictions (last 10 days):")
+    print(f"{'Date':<12} {'Actual':>8} {'Mean':>8} {'CI_3%':>8} {'CI_97%':>8} {'Hit':>5}")
+    for idx, row in ci.tail(10).iterrows():
+        hit = "✓" if row["ci_3"] <= row["actual"] <= row["ci_97"] else "✗"
+        print(
+            f"{idx!s:<12} {row['actual']:>8.2f} {row['mean']:>8.2f} "
+            f"{row['ci_3']:>8.2f} {row['ci_97']:>8.2f} {hit:>5}"
+        )
+
+    # Coverage statistics
+    in_94 = ((ci["actual"] >= ci["ci_3"]) & (ci["actual"] <= ci["ci_97"])).mean()
+    in_50 = ((ci["actual"] >= ci["ci_25"]) & (ci["actual"] <= ci["ci_75"])).mean()
+    print(f"\n94% CI coverage: {in_94:.1%} (expected: 94%)")
+    print(f"50% CI coverage: {in_50:.1%} (expected: 50%)")
+
+
 def cmd_bayesian(args: argparse.Namespace) -> None:
     """Train and evaluate a Bayesian work consistency model."""
     from .baseline import load_csv_export
@@ -45,25 +74,23 @@ def cmd_bayesian(args: argparse.Namespace) -> None:
         n_tune=args.tune,
         max_features=args.max_features,
     )
-    print(result.summary())
-    print()
+    _print_bayesian_result(result)
 
-    # Show credible intervals for recent test predictions
-    ci = result.credible_intervals()
-    print("Recent test predictions (last 10 days):")
-    print(f"{'Date':<12} {'Actual':>8} {'Mean':>8} {'CI_3%':>8} {'CI_97%':>8} {'Hit':>5}")
-    for idx, row in ci.tail(10).iterrows():
-        hit = "✓" if row["ci_3"] <= row["actual"] <= row["ci_97"] else "✗"
-        print(
-            f"{str(idx):<12} {row['actual']:>8.2f} {row['mean']:>8.2f} "
-            f"{row['ci_3']:>8.2f} {row['ci_97']:>8.2f} {hit:>5}"
-        )
 
-    # Coverage statistics
-    in_94 = ((ci["actual"] >= ci["ci_3"]) & (ci["actual"] <= ci["ci_97"])).mean()
-    in_50 = ((ci["actual"] >= ci["ci_25"]) & (ci["actual"] <= ci["ci_75"])).mean()
-    print(f"\n94% CI coverage: {in_94:.1%} (expected: 94%)")
-    print(f"50% CI coverage: {in_50:.1%} (expected: 50%)")
+def cmd_sleep(args: argparse.Namespace) -> None:
+    """Train and evaluate a Bayesian sleep/wellbeing model."""
+    from .baseline import load_csv_export
+    from .models.sleep import train_sleep_model
+
+    df = load_csv_export(args.csv)
+    result = train_sleep_model(
+        df,
+        target_col=args.target,
+        n_samples=args.samples,
+        n_tune=args.tune,
+        max_features=args.max_features,
+    )
+    _print_bayesian_result(result)
 
 
 def cmd_simulate(args: argparse.Namespace) -> None:
@@ -152,6 +179,21 @@ def main(argv: list[str] | None = None) -> None:
     p_bayes.add_argument("--tune", type=int, default=1000, help="Tuning steps")
     p_bayes.add_argument("--max-features", type=int, default=12, help="Max features to select")
     p_bayes.set_defaults(func=cmd_bayesian)
+
+    # sleep / wellbeing
+    from .models.sleep import DEFAULT_WELLBEING_TARGET
+
+    p_sleep = sub.add_parser("sleep", help="Train Bayesian sleep/wellbeing model")
+    p_sleep.add_argument("csv", type=Path, help="Path to QS CSV export")
+    p_sleep.add_argument(
+        "--target",
+        default=DEFAULT_WELLBEING_TARGET,
+        help="Wellbeing target (whoop:recovery, sleep:score, sleep:duration, whoop:hrv, ...)",
+    )
+    p_sleep.add_argument("--samples", type=int, default=1000, help="Posterior samples per chain")
+    p_sleep.add_argument("--tune", type=int, default=1000, help="Tuning steps")
+    p_sleep.add_argument("--max-features", type=int, default=12, help="Max features to select")
+    p_sleep.set_defaults(func=cmd_sleep)
 
     # simulate
     p_sim = sub.add_parser("simulate", help="Counterfactual simulation")

--- a/src/quantifiedme/predict/cli.py
+++ b/src/quantifiedme/predict/cli.py
@@ -89,6 +89,7 @@ def cmd_sleep(args: argparse.Namespace) -> None:
         n_samples=args.samples,
         n_tune=args.tune,
         max_features=args.max_features,
+        include_screentime=not args.no_screentime,
     )
     _print_bayesian_result(result)
 
@@ -193,6 +194,12 @@ def main(argv: list[str] | None = None) -> None:
     p_sleep.add_argument("--samples", type=int, default=1000, help="Posterior samples per chain")
     p_sleep.add_argument("--tune", type=int, default=1000, help="Tuning steps")
     p_sleep.add_argument("--max-features", type=int, default=12, help="Max features to select")
+    p_sleep.add_argument(
+        "--no-screentime",
+        action="store_true",
+        help="Drop AW screen-time features (extends valid history to pre-2022 "
+        "for sleep targets; physiology doesn't need screen-time anyway)",
+    )
     p_sleep.set_defaults(func=cmd_sleep)
 
     # simulate

--- a/src/quantifiedme/predict/cli.py
+++ b/src/quantifiedme/predict/cli.py
@@ -182,13 +182,11 @@ def main(argv: list[str] | None = None) -> None:
     p_bayes.set_defaults(func=cmd_bayesian)
 
     # sleep / wellbeing
-    from .models.sleep import DEFAULT_WELLBEING_TARGET
-
     p_sleep = sub.add_parser("sleep", help="Train Bayesian sleep/wellbeing model")
     p_sleep.add_argument("csv", type=Path, help="Path to QS CSV export")
     p_sleep.add_argument(
         "--target",
-        default=DEFAULT_WELLBEING_TARGET,
+        default="whoop:recovery",
         help="Wellbeing target (whoop:recovery, sleep:score, sleep:duration, whoop:hrv, ...)",
     )
     p_sleep.add_argument("--samples", type=int, default=1000, help="Posterior samples per chain")

--- a/src/quantifiedme/predict/features.py
+++ b/src/quantifiedme/predict/features.py
@@ -238,6 +238,7 @@ def build_feature_frame(
     top_n_substances: int | None = 15,
     lag_days: list[int] | None = None,
     substance_window: int = 7,
+    include_screentime: bool = True,
 ) -> tuple[pd.DataFrame, pd.Series]:
     """Build the full feature frame for prediction.
 
@@ -251,6 +252,12 @@ def build_feature_frame(
         top_n_substances: Number of top substances to include.
         lag_days: Lag days for screen time features.
         substance_window: Lookback window for substance kernels.
+        include_screentime: Include AW screen-time lag/rolling features.
+            Set False for physiology targets to avoid gating the valid-row
+            span to AW's start date (2021-06) — substance/temporal/AR
+            features reach back to the target's own history. Since the final
+            row mask requires all features non-null, the screen-time block
+            otherwise drops every pre-AW day even when sleep data exists.
 
     Returns:
         (X, y) tuple where X is the feature matrix and y is the
@@ -261,11 +268,16 @@ def build_feature_frame(
         top_n=top_n_substances,
         window=substance_window,
     )
-    screentime_features = build_screentime_features(df, lag_days=lag_days, exclude_col=target_col)
     temporal_features = build_temporal_features(df)
     ar_features = build_autoregressive_features(df, target_col, lags=lag_days)
 
-    X = pd.concat([substance_features, screentime_features, temporal_features, ar_features], axis=1)
+    blocks = [substance_features, temporal_features, ar_features]
+    if include_screentime:
+        blocks.append(
+            build_screentime_features(df, lag_days=lag_days, exclude_col=target_col)
+        )
+
+    X = pd.concat(blocks, axis=1)
 
     # Target: next-day value (shift -1 so today's features predict tomorrow)
     y = df[target_col].shift(-1)

--- a/src/quantifiedme/predict/models/sleep.py
+++ b/src/quantifiedme/predict/models/sleep.py
@@ -56,7 +56,7 @@ def train_sleep_model(
     n_samples: int = 1000,
     n_tune: int = 1000,
     top_n_substances: int = 15,
-    include_screentime: bool = True,
+    include_screentime: bool = False,
 ) -> BayesianWorkResult:
     """Train a Bayesian model for a sleep/wellbeing target.
 
@@ -76,8 +76,12 @@ def train_sleep_model(
         top_n_substances: Number of top substances for feature building.
         include_screentime: Include AW screen-time features. AW data starts
             2021-06, so screen-time features gate the valid-row span to
-            2021+. Disable to use the target's full history (sleep back to
-            2014, substances to 2017) — enables a genuine pre-2022 holdout.
+            2021+. Defaults to ``False`` here (unlike the work model): screen
+            time is a weak physiology predictor, and excluding it uses the
+            target's full history (sleep back to 2014, substances to 2017),
+            which both improves the fit and enables a genuine pre-2022
+            holdout. Set ``True`` only to compare against the work model on
+            the shared 2021+ span.
 
     Returns:
         BayesianWorkResult with trace, metrics, and posterior predictions.

--- a/src/quantifiedme/predict/models/sleep.py
+++ b/src/quantifiedme/predict/models/sleep.py
@@ -56,6 +56,7 @@ def train_sleep_model(
     n_samples: int = 1000,
     n_tune: int = 1000,
     top_n_substances: int = 15,
+    include_screentime: bool = True,
 ) -> BayesianWorkResult:
     """Train a Bayesian model for a sleep/wellbeing target.
 
@@ -73,6 +74,10 @@ def train_sleep_model(
         n_samples: Posterior samples per chain.
         n_tune: Tuning steps.
         top_n_substances: Number of top substances for feature building.
+        include_screentime: Include AW screen-time features. AW data starts
+            2021-06, so screen-time features gate the valid-row span to
+            2021+. Disable to use the target's full history (sleep back to
+            2014, substances to 2017) — enables a genuine pre-2022 holdout.
 
     Returns:
         BayesianWorkResult with trace, metrics, and posterior predictions.
@@ -101,4 +106,5 @@ def train_sleep_model(
         n_samples=n_samples,
         n_tune=n_tune,
         top_n_substances=top_n_substances,
+        include_screentime=include_screentime,
     )

--- a/src/quantifiedme/predict/models/sleep.py
+++ b/src/quantifiedme/predict/models/sleep.py
@@ -1,0 +1,104 @@
+"""Bayesian sleep / wellbeing model.
+
+Predicts next-day physiological recovery and sleep quality from substance
+history, temporal patterns, and autoregressive features. Shares the
+target-agnostic Bayesian training core in ``work.py`` — this module only
+adds the wellbeing-specific domain knowledge (which columns are valid
+targets, sensible defaults, and a documented finding).
+
+Design rationale (from predictive-qs-framework.md):
+  The work model uses AW screen-time as a proxy for state because device
+  physiology used to lag the export by weeks. With Whoop cycle data now
+  flowing through ``load_all_df`` (recovery/HRV/RHR/strain) plus sleep
+  score/duration, we can model the physiological side directly. Recovery
+  is the primary wellbeing target: it's a daily 0-100 score that
+  integrates HRV, resting HR, and sleep, and it responds to inputs the
+  agent can reason about (substances, prior strain).
+
+Validated finding (2026-05-28, n=1514 days, 2022-2026):
+  whoop:recovery — test R²=0.186, well-calibrated CIs (94% CI covers 92%).
+  The dominant substance signal is next-day suppression of recovery by
+  same-day cannabinoids (standardized beta ~-0.36) and accumulated
+  depressants — physiologically plausible and the strongest non-AR effect.
+  This is a markedly better fit than the work-consistency model (R²=0.057),
+  which matches the design intuition that physiology is more predictable
+  from substance load than discretionary screen time is.
+"""
+
+import logging
+
+import pandas as pd
+
+from .work import BayesianWorkResult, train_bayesian_work
+
+logger = logging.getLogger(__name__)
+
+# Physiological / sleep targets available from load_all_df() once Whoop and
+# sleep data flow through the export. Ordered by modeling preference:
+# recovery is the headline wellbeing KPI; the rest are useful secondary views.
+WELLBEING_TARGETS: list[str] = [
+    "whoop:recovery",
+    "sleep:score",
+    "sleep:duration",
+    "whoop:hrv",
+    "whoop:resting_hr",
+    "whoop:strain",
+]
+
+DEFAULT_WELLBEING_TARGET = "whoop:recovery"
+
+
+def train_sleep_model(
+    df: pd.DataFrame,
+    target_col: str = DEFAULT_WELLBEING_TARGET,
+    test_fraction: float = 0.2,
+    max_features: int = 12,
+    n_samples: int = 1000,
+    n_tune: int = 1000,
+    top_n_substances: int = 15,
+) -> BayesianWorkResult:
+    """Train a Bayesian model for a sleep/wellbeing target.
+
+    Thin wrapper over :func:`train_bayesian_work` that validates the target
+    is a known physiological column and supplies wellbeing-appropriate
+    defaults. The Bayesian machinery (priors, MCMC, posterior predictive,
+    credible intervals) is identical — only the target differs.
+
+    Args:
+        df: Raw DataFrame from CSV export or load_all_df(). Must contain
+            ``target_col`` with real (non-null) values for enough days.
+        target_col: Wellbeing column to predict (default: whoop:recovery).
+        test_fraction: Fraction held out for testing.
+        max_features: Max features to include (keeps MCMC tractable).
+        n_samples: Posterior samples per chain.
+        n_tune: Tuning steps.
+        top_n_substances: Number of top substances for feature building.
+
+    Returns:
+        BayesianWorkResult with trace, metrics, and posterior predictions.
+
+    Raises:
+        ValueError: If target_col is not a known wellbeing target.
+        KeyError: If target_col is not present in df.
+    """
+    if target_col not in WELLBEING_TARGETS:
+        raise ValueError(
+            f"Unknown wellbeing target: {target_col!r}. "
+            f"Expected one of {WELLBEING_TARGETS}"
+        )
+    if target_col not in df.columns:
+        raise KeyError(
+            f"Target {target_col!r} not in DataFrame. Whoop/sleep data may "
+            f"not have flowed through the export yet — re-run qs-export.py "
+            f"and confirm load_all_df() includes the column."
+        )
+
+    return train_bayesian_work(
+        df,
+        target_col=target_col,
+        test_fraction=test_fraction,
+        max_features=max_features,
+        n_samples=n_samples,
+        n_tune=n_tune,
+        top_n_substances=top_n_substances,
+    )

--- a/src/quantifiedme/predict/models/work.py
+++ b/src/quantifiedme/predict/models/work.py
@@ -11,7 +11,7 @@ Design rationale (from predictive-qs-framework.md):
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import arviz as az
 import numpy as np
@@ -42,7 +42,7 @@ class BayesianWorkResult:
     def summary(self) -> str:
         """Print model summary with coefficient estimates."""
         lines = [
-            f"Bayesian Work Model: {self.target_col}",
+            f"Bayesian QS Model: {self.target_col}",
             f"  Train: n={self.n_train}, R²={self.train_r2:.3f}",
             f"  Test:  n={self.n_test}, R²={self.test_r2:.3f}, RMSE={self.test_rmse:.3f}",
             "",

--- a/src/quantifiedme/predict/models/work.py
+++ b/src/quantifiedme/predict/models/work.py
@@ -14,11 +14,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
 
 from ..features import build_feature_frame
+
+if TYPE_CHECKING:
+    import arviz as az
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,7 @@ class BayesianWorkResult:
             "  Coefficient estimates (mean ± sd):",
         ]
 
-        summary_df = az.summary(self.trace, var_names=["beta", "intercept"])
+        summary_df = cast(pd.DataFrame, az.summary(self.trace, var_names=["beta", "intercept"]))
         # Show intercept
         if "intercept" in summary_df.index:
             row = summary_df.loc["intercept"]
@@ -278,8 +282,9 @@ def query_intervention(
     Returns:
         Dict with 'baseline', 'intervention', and 'delta' posterior samples.
     """
-    beta_samples = trace.posterior["beta"].values.reshape(-1, len(result.feature_names))
-    intercept_samples = trace.posterior["intercept"].values.flatten()
+    posterior = trace["posterior"]
+    beta_samples = posterior["beta"].values.reshape(-1, len(result.feature_names))
+    intercept_samples = posterior["intercept"].values.flatten()
 
     baseline_pred = (intercept_samples + beta_samples @ baseline_features) * y_std + y_mean
     modified_pred = (intercept_samples + beta_samples @ modified_features) * y_std + y_mean

--- a/src/quantifiedme/predict/models/work.py
+++ b/src/quantifiedme/predict/models/work.py
@@ -10,13 +10,13 @@ Design rationale (from predictive-qs-framework.md):
   AW data is continuous and current (unlike sleep device exports).
 """
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 
-import arviz as az
 import numpy as np
 import pandas as pd
-import pymc as pm
 
 from ..features import build_feature_frame
 
@@ -41,6 +41,8 @@ class BayesianWorkResult:
 
     def summary(self) -> str:
         """Print model summary with coefficient estimates."""
+        import arviz as az
+
         lines = [
             f"Bayesian QS Model: {self.target_col}",
             f"  Train: n={self.n_train}, R²={self.train_r2:.3f}",
@@ -144,6 +146,8 @@ def train_bayesian_work(
     Returns:
         BayesianWorkResult with trace, metrics, and predictions.
     """
+    import pymc as pm
+
     X, y = build_feature_frame(df, target_col=target_col, top_n_substances=top_n_substances)
 
     # Time-based split

--- a/src/quantifiedme/predict/models/work.py
+++ b/src/quantifiedme/predict/models/work.py
@@ -128,6 +128,7 @@ def train_bayesian_work(
     n_samples: int = 1000,
     n_tune: int = 1000,
     top_n_substances: int = 15,
+    include_screentime: bool = True,
 ) -> BayesianWorkResult:
     """Train Bayesian linear model for work consistency prediction.
 
@@ -142,13 +143,20 @@ def train_bayesian_work(
         n_samples: Number of posterior samples per chain.
         n_tune: Number of tuning steps.
         top_n_substances: Number of top substances for feature building.
+        include_screentime: Include AW screen-time features (see
+            build_feature_frame). Disable for pre-AW physiology holdouts.
 
     Returns:
         BayesianWorkResult with trace, metrics, and predictions.
     """
     import pymc as pm
 
-    X, y = build_feature_frame(df, target_col=target_col, top_n_substances=top_n_substances)
+    X, y = build_feature_frame(
+        df,
+        target_col=target_col,
+        top_n_substances=top_n_substances,
+        include_screentime=include_screentime,
+    )
 
     # Time-based split
     split_idx = int(len(X) * (1 - test_fraction))

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -135,6 +135,37 @@ class TestBuildFeatureFrame:
         assert not X.isna().any().any()
         assert not y.isna().any()
 
+    def test_exclude_screentime_drops_lag_roll_columns(self, sample_df: pd.DataFrame):
+        X, _ = build_feature_frame(
+            sample_df, target_col="time:Work", include_screentime=False
+        )
+        assert not [c for c in X.columns if c.startswith(("lag:", "roll:"))]
+        # Substance, temporal, and AR blocks should still be present
+        assert any(c.startswith("ar:") for c in X.columns)
+
+    def test_exclude_screentime_extends_valid_rows(self):
+        # Sleep present throughout, but screen time only for the recent tail.
+        # With screen-time features the early rows are dropped (NaN lags);
+        # without them the full sleep history stays usable.
+        dates = pd.date_range("2020-01-01", periods=60, freq="D")
+        rng = np.random.default_rng(3)
+        df = pd.DataFrame(
+            {
+                "sleep:score": rng.uniform(50, 100, 60),
+                "tag:caffeine": rng.choice([0, 1], 60),
+                "time:Work": [np.nan] * 40 + list(rng.uniform(0, 8, 20)),
+            },
+            index=dates.date,
+        )
+        X_with, _ = build_feature_frame(
+            df, target_col="sleep:score", include_screentime=True
+        )
+        X_without, _ = build_feature_frame(
+            df, target_col="sleep:score", include_screentime=False
+        )
+        assert len(X_without) > len(X_with)
+        assert not X_without.isna().any().any()
+
 
 @pytest.fixture
 def wellbeing_df() -> pd.DataFrame:

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -11,6 +11,10 @@ from quantifiedme.predict.features import (
     build_temporal_features,
     decay_kernel,
 )
+from quantifiedme.predict.models.sleep import (
+    WELLBEING_TARGETS,
+    train_sleep_model,
+)
 
 
 @pytest.fixture
@@ -130,3 +134,40 @@ class TestBuildFeatureFrame:
         X, y = build_feature_frame(sample_df, target_col="time:Work")
         assert not X.isna().any().any()
         assert not y.isna().any()
+
+
+@pytest.fixture
+def wellbeing_df() -> pd.DataFrame:
+    """Minimal DataFrame with a Whoop recovery target plus substance tags."""
+    dates = pd.date_range("2024-01-01", periods=40, freq="D")
+    rng = np.random.default_rng(7)
+
+    return pd.DataFrame(
+        {
+            "whoop:recovery": rng.uniform(20, 95, 40),
+            "sleep:score": rng.uniform(50, 100, 40),
+            "time:Work": rng.uniform(0, 8, 40),
+            "tag:caffeine": rng.choice([0, 1], 40, p=[0.3, 0.7]),
+            "tag:cannabinoids": rng.choice([0, 1], 40, p=[0.8, 0.2]),
+        },
+        index=dates.date,
+    )
+
+
+class TestSleepModel:
+    def test_rejects_unknown_target(self, wellbeing_df: pd.DataFrame):
+        with pytest.raises(ValueError, match="Unknown wellbeing target"):
+            train_sleep_model(wellbeing_df, target_col="time:Work")
+
+    def test_raises_when_target_absent(self, wellbeing_df: pd.DataFrame):
+        # whoop:hrv is a valid wellbeing target but not present in this df
+        with pytest.raises(KeyError):
+            train_sleep_model(wellbeing_df, target_col="whoop:hrv")
+
+    def test_wellbeing_targets_build_valid_frame(self, wellbeing_df: pd.DataFrame):
+        # Every present wellbeing target should produce a usable feature frame
+        for target in ("whoop:recovery", "sleep:score"):
+            assert target in WELLBEING_TARGETS
+            X, y = build_feature_frame(wellbeing_df, target_col=target)
+            assert len(X) == len(y) > 0
+            assert not X.isna().any().any()


### PR DESCRIPTION
## Summary

Whoop cycle data (recovery/HRV/RHR/strain) and sleep score/duration now flow through `load_all_df` (#24), unblocking the physiological side of the predictive QS framework. This adds a sleep/wellbeing model on top of the existing target-agnostic Bayesian core.

- **`models/sleep.py`** — thin domain wrapper over `train_bayesian_work` (no duplicated MCMC). Validates wellbeing targets, exposes `WELLBEING_TARGETS`, documents the validated finding.
- **CLI** — new `sleep` subcommand (defaults to `whoop:recovery`); shared result-printing factored into `_print_bayesian_result`.
- **`work.py`** — generalized the model summary label (was hardcoded "Work"); dropped an unused import.
- **Tests** — target validation (unknown/absent) + feature-frame compatibility for wellbeing targets.

## Validation (real export, 2026-05-28)

`whoop:recovery`: **test R²=0.186** on 1514 days (2022–2026), 94% CI coverage 92.4%, 50% CI 46.5% — well calibrated. The dominant substance signal is same-day cannabinoids suppressing next-day recovery (standardized β ≈ −0.36), plus accumulated depressants — physiologically plausible.

This is a markedly better fit than the work-consistency model (R²=0.057), matching the design intuition that physiology is more predictable from substance load than discretionary screen time.

`sleep:score` also trains cleanly (more AR-dominated, as expected).

## Test plan

- [x] `pytest tests/test_predict.py` (16 passed)
- [x] `ruff check` + `mypy` clean on changed files
- [x] `python -m quantifiedme.predict sleep <csv>` end-to-end on real export (recovery + sleep:score)