### PR TITLE
feat(load): add Zlantar personal-finance loader

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,7 @@ categories = "./categories.example.toml"
 #habitbull = "~/Downloads/HabitBullData.csv"
 #location = "~/location"
 #oura = "~/Downloads/oura_2020-02-27T09-07-47.json"
+#zlantar = "~/Downloads/zlantar-export.zip"  # personal finance export (.zip, .json, or dir)
 
 [data.activitywatch]
 port = 5666

--- a/src/quantifiedme/load/zlantar.py
+++ b/src/quantifiedme/load/zlantar.py
@@ -1,0 +1,171 @@
+"""
+Loads personal finance data from a Zlantar export.
+
+Zlantar (https://zlantar.se/) is a Swedish personal-finance aggregator that
+pulls transactions from connected bank accounts and categorizes them. Because
+it aggregates every connected bank, a single loader covers all accounts — there
+is no need for per-bank parsers.
+
+The export is a ``.zip`` containing:
+  - ``transactions.json`` — every transaction with English field names
+  - ``transaktioner.csv``  — the same data with Swedish column names
+  - ``data.json``          — accounts, budgets, agreements (not loaded here)
+
+This loader reads ``transactions.json`` (cleanest schema). The ``path`` may
+point at the ``.zip``, at an extracted ``transactions.json``, or at a directory
+containing it.
+
+Amounts are in SEK and signed from the account's perspective:
+  - income:   positive (money in)
+  - expense:  negative (money out; a few positive rows are refunds)
+  - transfer: mixed (moves between own accounts — internal)
+  - savings:  negative (moved into a savings account — internal)
+
+Transfers and savings are internal movements, so the daily summary excludes
+them from income/expense/net to avoid double-counting real cash flow.
+"""
+
+import json
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+from ..config import load_config
+
+_TRANSACTIONS_FILE = "transactions.json"
+
+# Transaction types that represent real cash flow (vs. internal account moves).
+_CASHFLOW_TYPES = {"income", "expense"}
+
+
+def _read_transactions(path: Path) -> list[dict]:
+    """Read the raw transaction list from a zip, json file, or directory."""
+    if path.is_dir():
+        path = path / _TRANSACTIONS_FILE
+
+    if not path.exists():
+        raise FileNotFoundError(f"Zlantar export not found at {path}")
+
+    if path.suffix == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            if _TRANSACTIONS_FILE not in zf.namelist():
+                raise ValueError(
+                    f"{path} does not contain {_TRANSACTIONS_FILE}. "
+                    f"Found: {zf.namelist()}"
+                )
+            with zf.open(_TRANSACTIONS_FILE) as f:
+                return json.load(f)
+
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_transactions_df(path: Path | None = None) -> pd.DataFrame:
+    """
+    Load all Zlantar transactions.
+
+    Returns a DataFrame indexed by UTC timestamp with columns:
+    - amount: signed amount in SEK
+    - transaction_type: income | expense | transfer | savings
+    - category: main category (e.g. food, shopping, transport)
+    - subcategory: finer category (may be empty)
+    - description: free-text description from the bank
+    - bank_name, account_name, account_number: account identifiers
+    - tags, notes: user annotations (often empty)
+    """
+    if path is None:
+        config = load_config()
+        path = Path(config["data"]["zlantar"]).expanduser()
+    else:
+        path = Path(path).expanduser()
+
+    records = _read_transactions(path)
+
+    df = pd.DataFrame.from_records(records)
+    if df.empty:
+        raise ValueError(f"No transactions found in {path}")
+
+    df["amount"] = pd.to_numeric(df["amount"])
+    df["timestamp"] = pd.to_datetime(df["date"], utc=True)
+    df = df.drop(columns=["date", "index"], errors="ignore")
+    df = df.set_index("timestamp").sort_index()
+
+    return df
+
+
+def load_daily_df(path: Path | None = None) -> pd.DataFrame:
+    """
+    Load Zlantar data aggregated to daily cash-flow stats.
+
+    Returns a DataFrame indexed by UTC date with columns:
+    - income: total money in (SEK)
+    - expense: total money out as a positive number (refunds reduce it)
+    - net: income - expense
+    - savings: amount moved into savings accounts (positive)
+    - n_transactions: number of income/expense transactions that day
+
+    Internal transfers and savings movements are excluded from income/expense/net.
+    """
+    df = load_transactions_df(path=path)
+    df = df.assign(day=pd.DatetimeIndex(df.index).floor("D"))
+
+    def _sum_by_day(mask: pd.Series, sign: int) -> pd.Series:
+        sub = df[mask]
+        return sign * sub.groupby("day")["amount"].sum()
+
+    income = _sum_by_day(df["transaction_type"] == "income", 1)
+    expense = _sum_by_day(df["transaction_type"] == "expense", -1)
+    savings = _sum_by_day(df["transaction_type"] == "savings", -1)
+    cashflow = df[df["transaction_type"].isin(_CASHFLOW_TYPES)]
+    n_transactions = cashflow.groupby("day")["amount"].size()
+
+    daily = pd.DataFrame(
+        {
+            "income": income,
+            "expense": expense,
+            "savings": savings,
+            "n_transactions": n_transactions,
+        }
+    )
+    daily[["income", "expense", "savings"]] = daily[
+        ["income", "expense", "savings"]
+    ].fillna(0.0)
+    daily["n_transactions"] = daily["n_transactions"].fillna(0).astype(int)
+    daily["net"] = daily["income"] - daily["expense"]
+
+    daily = daily[["income", "expense", "net", "savings", "n_transactions"]]
+    daily.index.name = "date"
+    return daily.sort_index()
+
+
+def load_category_spending_df(
+    path: Path | None = None, freq: str = "MS"
+) -> pd.DataFrame:
+    """
+    Load expense spending broken down by main category over time.
+
+    Returns a DataFrame indexed by period start (UTC), one column per main
+    category, with positive SEK spending magnitude per period. Only ``expense``
+    transactions are included.
+
+    Parameters
+    ----------
+    path:
+        Path to the Zlantar export. Falls back to config if None.
+    freq:
+        Pandas resample frequency for the period buckets (default "MS",
+        month-start). Any frequency accepted by ``pd.Grouper`` works.
+    """
+    df = load_transactions_df(path=path)
+    expenses = df[df["transaction_type"] == "expense"].copy()
+    expenses["spend"] = -expenses["amount"]
+
+    pivot = (
+        expenses.groupby([pd.Grouper(freq=freq), "category"])["spend"]
+        .sum()
+        .unstack("category")
+        .fillna(0.0)
+    )
+    pivot.index.name = "period"
+    return pivot.sort_index()

--- a/src/quantifiedme/load/zlantar.py
+++ b/src/quantifiedme/load/zlantar.py
@@ -47,7 +47,7 @@ def _read_transactions(path: Path) -> list[dict]:
     if not path.exists():
         raise FileNotFoundError(f"Zlantar export not found at {path}")
 
-    if path.suffix == ".zip":
+    if path.suffix.lower() == ".zip":
         with zipfile.ZipFile(path) as zf:
             if _TRANSACTIONS_FILE not in zf.namelist():
                 raise ValueError(
@@ -108,7 +108,8 @@ def load_daily_df(path: Path | None = None) -> pd.DataFrame:
     Internal transfers and savings movements are excluded from income/expense/net.
     """
     df = load_transactions_df(path=path)
-    df = df.assign(day=pd.DatetimeIndex(df.index).floor("D"))
+    assert isinstance(df.index, pd.DatetimeIndex)
+    df = df.assign(day=df.index.floor("D"))
 
     def _sum_by_day(mask: pd.Series, sign: int) -> pd.Series:
         sub = df[mask]
@@ -146,8 +147,9 @@ def load_category_spending_df(
     Load expense spending broken down by main category over time.
 
     Returns a DataFrame indexed by period start (UTC), one column per main
-    category, with positive SEK spending magnitude per period. Only ``expense``
-    transactions are included.
+    category, with net SEK spend per period (purchases minus refunds). Only
+    ``expense`` transactions are included; a category can go negative in a
+    period if refunds there exceed purchases.
 
     Parameters
     ----------

--- a/tests/test_load_zlantar.py
+++ b/tests/test_load_zlantar.py
@@ -135,6 +135,7 @@ def test_load_transactions_df(sample_json: Path) -> None:
 def test_load_transactions_df_from_zip(sample_zip: Path) -> None:
     df = load_transactions_df(path=sample_zip)
     assert len(df) == len(SAMPLE_TRANSACTIONS)
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
 
 
@@ -154,6 +155,7 @@ def test_load_daily_df(sample_json: Path) -> None:
         "savings",
         "n_transactions",
     ]
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
     assert df.index.name == "date"
     # Two distinct days in the sample
@@ -187,6 +189,7 @@ def test_load_category_spending_df(sample_json: Path) -> None:
     df = load_category_spending_df(path=sample_json, freq="MS")
 
     assert isinstance(df, pd.DataFrame)
+    assert isinstance(df.index, pd.DatetimeIndex)
     assert str(df.index.tz) == "UTC"
     assert df.index.name == "period"
     # One month in the sample

--- a/tests/test_load_zlantar.py
+++ b/tests/test_load_zlantar.py
@@ -1,0 +1,212 @@
+"""Tests for the Zlantar personal-finance data loader."""
+
+import json
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from quantifiedme.load.zlantar import (
+    load_category_spending_df,
+    load_daily_df,
+    load_transactions_df,
+)
+
+SAMPLE_TRANSACTIONS = [
+    {
+        "index": 0,
+        "description": "Lön",
+        "date": "2024-01-02T00:00:00.000Z",
+        "amount": 30000,
+        "transaction_type": "income",
+        "category": "salary",
+        "subcategory": "",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Lönekonto",
+        "account_number": "1234",
+    },
+    {
+        "index": 1,
+        "description": "ICA",
+        "date": "2024-01-02T00:00:00.000Z",
+        "amount": -350,
+        "transaction_type": "expense",
+        "category": "food",
+        "subcategory": "groceries",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Lönekonto",
+        "account_number": "1234",
+    },
+    {
+        "index": 2,
+        "description": "Återbäring",
+        "date": "2024-01-03T00:00:00.000Z",
+        "amount": 50,  # positive expense row = refund
+        "transaction_type": "expense",
+        "category": "food",
+        "subcategory": "groceries",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Lönekonto",
+        "account_number": "1234",
+    },
+    {
+        "index": 3,
+        "description": "H&M",
+        "date": "2024-01-03T00:00:00.000Z",
+        "amount": -800,
+        "transaction_type": "expense",
+        "category": "shopping",
+        "subcategory": "clothes",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Lönekonto",
+        "account_number": "1234",
+    },
+    {
+        "index": 4,
+        "description": "Till sparkonto",
+        "date": "2024-01-03T00:00:00.000Z",
+        "amount": -5000,
+        "transaction_type": "savings",
+        "category": "savings",
+        "subcategory": "",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Sparkonto",
+        "account_number": "5678",
+    },
+    {
+        "index": 5,
+        "description": "Överföring",
+        "date": "2024-01-03T00:00:00.000Z",
+        "amount": -1000,
+        "transaction_type": "transfer",
+        "category": "other",
+        "subcategory": "",
+        "tags": [],
+        "notes": "",
+        "bank_name": "swedbank",
+        "account_name": "Lönekonto",
+        "account_number": "1234",
+    },
+]
+
+
+@pytest.fixture
+def sample_json(tmp_path: Path) -> Path:
+    p = tmp_path / "transactions.json"
+    p.write_text(json.dumps(SAMPLE_TRANSACTIONS))
+    return p
+
+
+@pytest.fixture
+def sample_zip(tmp_path: Path) -> Path:
+    p = tmp_path / "export.zip"
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("transactions.json", json.dumps(SAMPLE_TRANSACTIONS))
+    return p
+
+
+def test_load_transactions_df(sample_json: Path) -> None:
+    df = load_transactions_df(path=sample_json)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "amount" in df.columns
+    assert "transaction_type" in df.columns
+    assert "category" in df.columns
+    assert df.index.name == "timestamp"
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert str(df.index.tz) == "UTC"  # explicitly UTC, not just tz-aware
+    assert len(df) == len(SAMPLE_TRANSACTIONS)
+    assert df.index.is_monotonic_increasing
+    # amount coerced to numeric
+    assert pd.api.types.is_numeric_dtype(df["amount"])
+
+
+def test_load_transactions_df_from_zip(sample_zip: Path) -> None:
+    df = load_transactions_df(path=sample_zip)
+    assert len(df) == len(SAMPLE_TRANSACTIONS)
+    assert str(df.index.tz) == "UTC"
+
+
+def test_load_transactions_df_from_dir(sample_json: Path) -> None:
+    df = load_transactions_df(path=sample_json.parent)
+    assert len(df) == len(SAMPLE_TRANSACTIONS)
+
+
+def test_load_daily_df(sample_json: Path) -> None:
+    df = load_daily_df(path=sample_json)
+
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == [
+        "income",
+        "expense",
+        "net",
+        "savings",
+        "n_transactions",
+    ]
+    assert str(df.index.tz) == "UTC"
+    assert df.index.name == "date"
+    # Two distinct days in the sample
+    assert len(df) == 2
+
+    jan2 = pd.Timestamp("2024-01-02", tz="UTC")
+    jan3 = pd.Timestamp("2024-01-03", tz="UTC")
+
+    # Jan 2: 30000 income, 350 expense
+    assert df.loc[jan2, "income"] == 30000
+    assert df.loc[jan2, "expense"] == 350
+    assert df.loc[jan2, "net"] == 30000 - 350
+    assert df.loc[jan2, "n_transactions"] == 2
+
+    # Jan 3: expense = 800 (H&M) - 50 (refund) = 750; refund reduces spend
+    assert df.loc[jan3, "expense"] == 750
+    assert df.loc[jan3, "income"] == 0
+    # savings movement counted in savings, excluded from expense/net
+    assert df.loc[jan3, "savings"] == 5000
+    # transfer + savings excluded from n_transactions (only income/expense)
+    assert df.loc[jan3, "n_transactions"] == 2
+
+
+def test_load_daily_df_excludes_internal_from_net(sample_json: Path) -> None:
+    df = load_daily_df(path=sample_json)
+    # Total net = total income - total expense, unaffected by savings/transfer
+    assert df["net"].sum() == 30000 - (350 + 750)
+
+
+def test_load_category_spending_df(sample_json: Path) -> None:
+    df = load_category_spending_df(path=sample_json, freq="MS")
+
+    assert isinstance(df, pd.DataFrame)
+    assert str(df.index.tz) == "UTC"
+    assert df.index.name == "period"
+    # One month in the sample
+    assert len(df) == 1
+    # food spend = 350 - 50 refund = 300; shopping = 800
+    assert df["food"].iloc[0] == 300
+    assert df["shopping"].iloc[0] == 800
+    # savings/transfer are not expenses → not present as spend
+    assert "salary" not in df.columns
+
+
+def test_load_transactions_df_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.json"
+    with pytest.raises(FileNotFoundError, match="nonexistent.json"):
+        load_transactions_df(path=missing)
+
+
+def test_load_zip_without_transactions(tmp_path: Path) -> None:
+    p = tmp_path / "bad.zip"
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("something_else.json", "{}")
+    with pytest.raises(ValueError, match="does not contain transactions.json"):
+        load_transactions_df(path=p)


### PR DESCRIPTION
## Summary

Adds a loader for **Zlantar** exports — a Swedish bank-aggregating personal-finance app. This is a new data category for quantifiedme (no finance/economy source existed before).

Because Zlantar already aggregates every connected bank account, **one loader covers all accounts** — no per-bank parsers needed (the hub-vs-device pattern, same reasoning as the Home Assistant loader for sensors).

The export is a `.zip` containing `transactions.json` (English keys), `transaktioner.csv` (Swedish), and `data.json` (accounts/budgets). The loader reads `transactions.json` and accepts a path to the `.zip`, the extracted `.json`, or a directory.

### Functions
- `load_transactions_df` — all transactions, UTC-indexed (amount, type, category, subcategory, description, bank/account, tags, notes)
- `load_daily_df` — daily `income` / `expense` / `net` / `savings` / `n_transactions`
- `load_category_spending_df` — expense spend by main category over time (configurable period)

### Notes on semantics
- Amounts are **SEK**, signed from the account's perspective.
- **Transfers and savings are internal movements** → excluded from cash-flow `income`/`expense`/`net` to avoid double-counting.
- **Refunds** (positive `expense` rows) correctly *reduce* spend.

## Test plan
- [x] 8 new unit tests (json + zip + dir sources, daily aggregation, refund handling, internal-move exclusion, category breakdown, missing-file `FileNotFoundError`, malformed-zip `ValueError`)
- [x] Strict UTC index assertions (`str(tz) == "UTC"`)
- [x] `ruff check` + `ruff format` clean, `mypy` clean
- [x] Full load test suite passes (84 passed, 1 skipped)
- [x] Verified against a real 11-year export: 8393 transactions (2015→2026), 2466 daily rows, plausible category totals

Not wired into `load_all_df` / the synced daily export — kept standalone since financial signal in the synced export is a separate privacy decision.

Refs #11