### PR TITLE
docs(readme): list comms_backup reader for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Types of data supported:
    - Easy to adapt to any other habit app that supports CSV export
  - Drug consumption (from QSlang)
  - Communication data (calls/SMS from the "SMS Backup & Restore" Android app)
-   - Low-level streaming XML reader in `load/comms_backup.py`; consumers apply their own privacy filtering/aggregation on top.
+   - Low-level streaming XML reader in `src/quantifiedme/load/comms_backup.py`; consumers apply their own privacy filtering/aggregation on top.
 
 Can load data from:
 
@@ -38,7 +38,7 @@ Can load data from:
  - Fitbit
  - Whoop
  - Oura
- - SMS Backup & Restore (calls/SMS — see `load/comms_backup.py`)
+ - SMS Backup & Restore (calls/SMS — see `src/quantifiedme/load/comms_backup.py`)
  - EEG devices (WIP)
  - ...and more (see `src/quantifiedme/load/`)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Types of data supported:
    - Includes a calendar plot.
    - Easy to adapt to any other habit app that supports CSV export
  - Drug consumption (from QSlang)
+ - Communication data (calls/SMS from the "SMS Backup & Restore" Android app)
+   - Low-level streaming XML reader in `load/comms_backup.py`; consumers apply their own privacy filtering/aggregation on top.
 
 Can load data from:
 
@@ -36,6 +38,7 @@ Can load data from:
  - Fitbit
  - Whoop
  - Oura
+ - SMS Backup & Restore (calls/SMS — see `load/comms_backup.py`)
  - EEG devices (WIP)
  - ...and more (see `src/quantifiedme/load/`)
 


### PR DESCRIPTION
Follow-up to #26. Erik asked there: "should probably mention the reader in the top-level README or a similar inventory for discoverability."

Adds the calls/SMS `comms_backup` reader ("SMS Backup & Restore" Android export) to both README inventories:
- **Types of data supported** — new *Communication data* entry, noting consumers apply their own privacy filtering/aggregation on top of the low-level reader.
- **Can load data from** — `SMS Backup & Restore` with a pointer to `load/comms_backup.py`.

Docs-only, no code change.