### PR TITLE
fix(ci): give the notebooks job's poetry cache a bustable key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,15 +150,20 @@ jobs:
 
     - name: Cache poetry dependencies
       uses: actions/cache@v4
-      with:
-        path: ${{ steps.poetry-cache.outputs.dir }}
+      env:
         # `setup-python`'s built-in `cache: poetry` has no manual cache-busting
         # lever, so a corrupted cache (see #29) can only be cleared by a repo
-        # admin via Settings > Actions > Caches. Bump the `v1` suffix below to
-        # force a fresh cache without needing that access.
-        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('poetry.lock') }}
+        # admin via Settings > Actions > Caches. Bump this to force a fresh
+        # cache without needing that access. A single source of truth (rather
+        # than repeating the suffix in `key` and `restore-keys` separately)
+        # means bumping it can't accidentally desync the two and fall back to
+        # a stale, possibly-corrupted cache on a partial restore-keys match.
+        POETRY_CACHE_VERSION: v1
+      with:
+        path: ${{ steps.poetry-cache.outputs.dir }}
+        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ env.POETRY_CACHE_VERSION }}-${{ hashFiles('poetry.lock') }}
         restore-keys: |
-          poetry-${{ runner.os }}-${{ matrix.python-version }}-v1-
+          poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ env.POETRY_CACHE_VERSION }}-
 
     - name: Install deps
       run: poetry install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,22 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'poetry'
+
+    - name: Get poetry cache dir
+      id: poetry-cache
+      run: echo "dir=$(poetry config cache-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache poetry dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.poetry-cache.outputs.dir }}
+        # `setup-python`'s built-in `cache: poetry` has no manual cache-busting
+        # lever, so a corrupted cache (see #29) can only be cleared by a repo
+        # admin via Settings > Actions > Caches. Bump the `v1` suffix below to
+        # force a fresh cache without needing that access.
+        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('poetry.lock') }}
+        restore-keys: |
+          poetry-${{ runner.os }}-${{ matrix.python-version }}-v1-
 
     - name: Install deps
       run: poetry install


### PR DESCRIPTION
Closes #29.

## Root cause

The `notebooks` job's Python 3.10 poetry cache is corrupted (`FileNotFoundError` on a missing `ipykernel` dist-info in the cached venv). `actions/setup-python`'s built-in `cache: 'poetry'` shortcut computes its cache key automatically from `poetry.lock`, with no lever to force a fresh cache from the workflow file — which is exactly why the issue's suggested fix requires a repo admin to manually delete the cache via Settings > Actions > Caches.

## Fix

Replaced the `cache: 'poetry'` shortcut in the `notebooks` job with an explicit `actions/cache@v4` step keyed on a manual version suffix (`v1`). Two effects:

- Immediately unblocks the currently-corrupted cache, since `actions/cache`'s key namespace is distinct from `setup-python`'s internal one.
- Gives a durable escape hatch: if this happens again, bumping the suffix (`v1` -> `v2`) in a follow-up commit busts the cache without needing dashboard/admin access.

Scoped to just the `notebooks` job since that's the one actually reported as failing; `tests` and `typecheck` still use the `cache: 'poetry'` shortcut and aren't affected today.

## Testing

This is a GitHub-Actions-only failure (a remote cache corruption), so it can't be reproduced locally. I validated the workflow YAML parses correctly and ran `actionlint` on the file — the only warnings it raises are pre-existing shellcheck nits elsewhere in the file, unrelated to this change. The real confirmation is this PR's own CI run for the `notebooks` job.